### PR TITLE
added Base2Tone colorschemes

### DIFF
--- a/terminus-community-color-schemes/schemes/base2tone-cave-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-cave-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #9f999b
+*.background:  #222021
+*.cursorColor: #996e00
+!
+! Black
+*.color0:      #222021
+*.color8:      #635f60
+!
+! Red
+*.color1:      #936c7a
+*.color9:      #ddaf3c
+!
+! Green
+*.color2:      #cca133
+*.color10:     #2f2d2e
+!
+! Yellow
+*.color3:      #ffcc4d
+*.color11:     #565254
+!
+! Blue
+*.color4:      #9c818b
+*.color12:     #706b6d
+!
+! Magenta
+*.color5:      #cca133
+*.color13:     #f0a8c1
+!
+! Cyan
+*.color6:      #d27998
+*.color14:     #c39622
+!
+! White
+*.color7:      #9f999b
+*.color15:     #ffebf2
+!
+! Bold, Italic, Underline
+*.colorBD:     #9f999b
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-desert-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-desert-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #ada594
+*.background:  #292724
+*.cursorColor: #bc672f
+!
+! Black
+*.color0:      #292724
+*.color8:      #7e7767
+!
+! Red
+*.color1:      #816f4b
+*.color9:      #f29d63
+!
+! Green
+*.color2:      #ec9255
+*.color10:     #3d3a34
+!
+! Yellow
+*.color3:      #ffb380
+*.color11:     #615c51
+!
+! Blue
+*.color4:      #957e50
+*.color12:     #908774
+!
+! Magenta
+*.color5:      #ec9255
+*.color13:     #ddcba6
+!
+! Cyan
+*.color6:      #ac8e53
+*.color14:     #e58748
+!
+! White
+*.color7:      #ada594
+*.color15:     #f2ead9
+!
+! Bold, Italic, Underline
+*.colorBD:     #ada594
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-drawbridge-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-drawbridge-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #9094a7
+*.background:  #1b1f32
+*.cursorColor: #289dbd
+!
+! Black
+*.color0:      #1b1f32
+*.color8:      #51587b
+!
+! Red
+*.color1:      #627af4
+*.color9:      #75d5f0
+!
+! Green
+*.color2:      #67c9e4
+*.color10:     #252a41
+!
+! Yellow
+*.color3:      #99e9ff
+*.color11:     #444b6f
+!
+! Blue
+*.color4:      #7289fd
+*.color12:     #5e6587
+!
+! Magenta
+*.color5:      #67c9e4
+*.color13:     #c3cdfe
+!
+! Cyan
+*.color6:      #8b9efd
+*.color14:     #5cbcd6
+!
+! White
+*.color7:      #9094a7
+*.color15:     #e1e6ff
+!
+! Bold, Italic, Underline
+*.colorBD:     #9094a7
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-evening-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-evening-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #a4a1b5
+*.background:  #2a2734
+*.cursorColor: #b37537
+!
+! Black
+*.color0:      #2a2734
+*.color8:      #6c6783
+!
+! Red
+*.color1:      #8a75f5
+*.color9:      #ffb870
+!
+! Green
+*.color2:      #ffad5c
+*.color10:     #363342
+!
+! Yellow
+*.color3:      #ffcc99
+*.color11:     #545167
+!
+! Blue
+*.color4:      #9a86fd
+*.color12:     #787391
+!
+! Magenta
+*.color5:      #ffad5c
+*.color13:     #d9d2fe
+!
+! Cyan
+*.color6:      #afa0fe
+*.color14:     #ffa142
+!
+! White
+*.color7:      #a4a1b5
+*.color15:     #eeebff
+!
+! Bold, Italic, Underline
+*.colorBD:     #a4a1b5
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-forest-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-forest-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #a1b5a1
+*.background:  #2a2d2a
+*.cursorColor: #656b47
+!
+! Black
+*.color0:      #2a2d2a
+*.color8:      #535f53
+!
+! Red
+*.color1:      #5c705c
+*.color9:      #cbe25a
+!
+! Green
+*.color2:      #bfd454
+*.color10:     #353b35
+!
+! Yellow
+*.color3:      #e5fb79
+*.color11:     #485148
+!
+! Blue
+*.color4:      #687d68
+*.color12:     #5e6e5e
+!
+! Magenta
+*.color5:      #bfd454
+*.color13:     #c8e4c8
+!
+! Cyan
+*.color6:      #8fae8f
+*.color14:     #b1c44f
+!
+! White
+*.color7:      #a1b5a1
+*.color15:     #f0fff0
+!
+! Bold, Italic, Underline
+*.colorBD:     #a1b5a1
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-heath-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-heath-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #9e999f
+*.background:  #222022
+*.cursorColor: #995900
+!
+! Black
+*.color0:      #222022
+*.color8:      #635f63
+!
+! Red
+*.color1:      #8f6c93
+*.color9:      #d9b98c
+!
+! Green
+*.color2:      #cc8c33
+*.color10:     #2f2d2f
+!
+! Yellow
+*.color3:      #ffd599
+*.color11:     #575158
+!
+! Blue
+*.color4:      #9a819c
+*.color12:     #6f6b70
+!
+! Magenta
+*.color5:      #cc8c33
+*.color13:     #eaa8f0
+!
+! Cyan
+*.color6:      #cb79d2
+*.color14:     #c38022
+!
+! White
+*.color7:      #9e999f
+*.color15:     #fdebff
+!
+! Bold, Italic, Underline
+*.colorBD:     #9e999f
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-heath-light
+++ b/terminus-community-color-schemes/schemes/base2tone-heath-light
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #575158
+*.background:  #fbfaf9
+*.cursorColor: #eaa8f0
+!
+! Black
+*.color0:      #222022
+*.color8:      #635f63
+!
+! Red
+*.color1:      #8f6c93
+*.color9:      #d9b98c
+!
+! Green
+*.color2:      #cc8c33
+*.color10:     #2f2d2f
+!
+! Yellow
+*.color3:      #ffd599
+*.color11:     #575158
+!
+! Blue
+*.color4:      #9a819c
+*.color12:     #6f6b70
+!
+! Magenta
+*.color5:      #b87414
+*.color13:     #eaa8f0
+!
+! Cyan
+*.color6:      #cb79d2
+*.color14:     #c38022
+!
+! White
+*.color7:      #9e999f
+*.color15:     #fbfaf9
+!
+! Bold, Italic, Underline
+*.colorBD:     #575158
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-lake-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-lake-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #7ba8b7
+*.background:  #192d34
+*.cursorColor: #84740b
+!
+! Black
+*.color0:      #192d34
+*.color8:      #3d6876
+!
+! Red
+*.color1:      #3e91ac
+*.color9:      #d6c65c
+!
+! Green
+*.color2:      #cbbb4d
+*.color10:     #223c44
+!
+! Yellow
+*.color3:      #ffeb66
+*.color11:     #335966
+!
+! Blue
+*.color4:      #499fbc
+*.color12:     #467686
+!
+! Magenta
+*.color5:      #cbbb4d
+*.color13:     #a5d8e9
+!
+! Cyan
+*.color6:      #62b1cb
+*.color14:     #c4b031
+!
+! White
+*.color7:      #7ba8b7
+*.color15:     #e1f7ff
+!
+! Bold, Italic, Underline
+*.colorBD:     #7ba8b7
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-meadow-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-meadow-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #7b9eb7
+*.background:  #192834
+*.cursorColor: #4d8217
+!
+! Black
+*.color0:      #192834
+*.color8:      #3d5e76
+!
+! Red
+*.color1:      #277fbe
+*.color9:      #8cdd3c
+!
+! Green
+*.color2:      #80bf40
+*.color10:     #223644
+!
+! Yellow
+*.color3:      #a6f655
+*.color11:     #335166
+!
+! Blue
+*.color4:      #4299d7
+*.color12:     #466b86
+!
+! Magenta
+*.color5:      #80bf40
+*.color13:     #afddfe
+!
+! Cyan
+*.color6:      #47adf5
+*.color14:     #73b234
+!
+! White
+*.color7:      #7b9eb7
+*.color15:     #d1ecff
+!
+! Bold, Italic, Underline
+*.colorBD:     #7b9eb7
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-morning-light
+++ b/terminus-community-color-schemes/schemes/base2tone-morning-light
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #4f5664
+*.background:  #faf8f5
+*.cursorColor: #b7c9eb
+!
+! Black
+*.color0:      #232834
+*.color8:      #656e81
+!
+! Red
+*.color1:      #1659df
+*.color9:      #c6b28b
+!
+! Green
+*.color2:      #b29762
+*.color10:     #31363f
+!
+! Yellow
+*.color3:      #e5ddcd
+*.color11:     #4f5664
+!
+! Blue
+*.color4:      #3d75e6
+*.color12:     #707a8f
+!
+! Magenta
+*.color5:      #896724
+*.color13:     #b7c9eb
+!
+! Cyan
+*.color6:      #728fcb
+*.color14:     #9a7c42
+!
+! White
+*.color7:      #8d95a5
+*.color15:     #faf8f5
+!
+! Bold, Italic, Underline
+*.colorBD:     #4f5664
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-pool-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-pool-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #9a90a7
+*.background:  #2a2433
+*.cursorColor: #cf504a
+!
+! Black
+*.color0:      #2a2433
+*.color8:      #635775
+!
+! Red
+*.color1:      #aa75f5
+*.color9:      #fc8983
+!
+! Green
+*.color2:      #f87972
+*.color10:     #372f42
+!
+! Yellow
+*.color3:      #ffb6b3
+*.color11:     #574b68
+!
+! Blue
+*.color4:      #b886fd
+*.color12:     #706383
+!
+! Magenta
+*.color5:      #f87972
+*.color13:     #e4d2fe
+!
+! Cyan
+*.color6:      #c7a0fe
+*.color14:     #f36f68
+!
+! White
+*.color7:      #9a90a7
+*.color15:     #f3ebff
+!
+! Bold, Italic, Underline
+*.colorBD:     #9a90a7
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-sea-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-sea-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #a1aab5
+*.background:  #1d262f
+*.cursorColor: #067953
+!
+! Black
+*.color0:      #1d262f
+*.color8:      #4a5f78
+!
+! Red
+*.color1:      #34659d
+*.color9:      #14e19d
+!
+! Green
+*.color2:      #0fc78a
+*.color10:     #27323f
+!
+! Yellow
+*.color3:      #47ebb4
+*.color11:     #405368
+!
+! Blue
+*.color4:      #57718e
+*.color12:     #738191
+!
+! Magenta
+*.color5:      #0fc78a
+*.color13:     #afd4fe
+!
+! Cyan
+*.color6:      #6e9bcf
+*.color14:     #0db57d
+!
+! White
+*.color7:      #a1aab5
+*.color15:     #ebf4ff
+!
+! Bold, Italic, Underline
+*.colorBD:     #a1aab5
+!*.colorIT:
+!*.colorUL:

--- a/terminus-community-color-schemes/schemes/base2tone-space-dark
+++ b/terminus-community-color-schemes/schemes/base2tone-space-dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xrecources.py
+!
+*.foreground:  #a1a1b5
+*.background:  #24242e
+*.cursorColor: #b25424
+!
+! Black
+*.color0:      #24242e
+*.color8:      #5b5b76
+!
+! Red
+*.color1:      #7676f4
+*.color9:      #f37b3f
+!
+! Green
+*.color2:      #ec7336
+*.color10:     #333342
+!
+! Yellow
+*.color3:      #fe8c52
+*.color11:     #515167
+!
+! Blue
+*.color4:      #767693
+*.color12:     #737391
+!
+! Magenta
+*.color5:      #ec7336
+*.color13:     #cecee3
+!
+! Cyan
+*.color6:      #8a8aad
+*.color14:     #e66e33
+!
+! White
+*.color7:      #a1a1b5
+*.color15:     #ebebff
+!
+! Bold, Italic, Underline
+*.colorBD:     #a1a1b5
+!*.colorIT:
+!*.colorUL:


### PR DESCRIPTION
[Base2Tone colorschemes](http://base2t.one) are based on [DuoTone themes](http://simurai.com/projects/2016/01/01/duotone-themes) by [Simurai](http://simurai.com/) for Atom. 

I converted these themes from the ones I made for iTerm2.

- base2tone-evening-dark should come close to the default duotone-dark theme by Simurai for Atom
- base2tone-morning-light should come close to the default duotone-light theme by Simurai for Atom

like:

- base2tone-sea-dark should come close to Sea duotone theme by Simurai for Atom
- base2tone-space-dark should come close to Space duotone theme by Simurai for Atom
- base2tone-earth-dark should come close to Earth duotone theme by Simurai for Atom
- base2tone-forest-dark should come close to Forest duotone theme by Simurai for Atom

The others are colorschemes I created myself based on the duotone concept.