### PR TITLE
adding line to readme for copy and paste hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   * Theming and color schemes
   * Configurable hotkey schemes
   * **GNU Screen** style hotkeys available by default
+  * Default Linux style hotkeys for Copy(`Ctrl`+`Shift`+`C`), and Paste(`Ctrl`+`Shift`+`V`)
   * Full Unicode support including double-width characters
   * Doesn't choke on fast-flowing outputs
   * Tab persistence on macOS and Linux


### PR DESCRIPTION
Many windows users may not be familiar with the hotkeys used in Linux terminal to copy and paste so it might be helpful to add it to the readme with terminus being cross platform and all. 