### PR TITLE
add Base16 color scheme

### DIFF
--- a/terminus-community-color-schemes/package.json
+++ b/terminus-community-color-schemes/package.json
@@ -2,7 +2,9 @@
   "name": "terminus-community-color-schemes",
   "version": "1.0.0-alpha.14.2",
   "description": "Community color schemes for Terminus",
-  "keywords": ["terminus-plugin"],
+  "keywords": [
+    "terminus-plugin"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/terminus-community-color-schemes/schemes/Base16 Default Dark
+++ b/terminus-community-color-schemes/schemes/Base16 Default Dark
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xreources.py
+!
+*.foreground:  #d8d8d8
+*.background:  #181818
+*.cursorColor: #d8d8d8
+!
+! Black
+*.color0:      #181818
+*.color8:      #585858
+!
+! Red
+*.color1:      #ab4642
+*.color9:      #dc9656
+!
+! Green
+*.color2:      #a1b56c
+*.color10:     #282828
+!
+! Yellow
+*.color3:      #f7ca88
+*.color11:     #383838
+!
+! Blue
+*.color4:      #7cafc2
+*.color12:     #b8b8b8
+!
+! Magenta
+*.color5:      #ba8baf
+*.color13:     #e8e8e8
+!
+! Cyan
+*.color6:      #86c1b9
+*.color14:     #a16946
+!
+! White
+*.color7:      #d8d8d8
+*.color15:     #f8f8f8
+!
+! Bold, Italic, Underline
+*.colorBD:     #d8d8d8
+!*.colorIT:
+!*.colorUL:

--- a/terminus-core/package.json
+++ b/terminus-core/package.json
@@ -2,7 +2,9 @@
   "name": "terminus-core",
   "version": "1.0.0-alpha.14",
   "description": "Terminus core",
-  "keywords": ["terminus-plugin"],
+  "keywords": [
+    "terminus-plugin"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/terminus-plugin-manager/package.json
+++ b/terminus-plugin-manager/package.json
@@ -2,7 +2,9 @@
   "name": "terminus-plugin-manager",
   "version": "1.0.0-alpha.14",
   "description": "Terminus' plugin manager",
-  "keywords": ["terminus-plugin"],
+  "keywords": [
+    "terminus-plugin"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/terminus-settings/package.json
+++ b/terminus-settings/package.json
@@ -2,7 +2,9 @@
   "name": "terminus-settings",
   "version": "1.0.0-alpha.14",
   "description": "Terminus terminal settings page",
-  "keywords": ["terminus-plugin"],
+  "keywords": [
+    "terminus-plugin"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/terminus-terminal/package.json
+++ b/terminus-terminal/package.json
@@ -2,7 +2,9 @@
   "name": "terminus-terminal",
   "version": "1.0.0-alpha.14",
   "description": "Terminus' terminal emulation core",
-  "keywords": ["terminus-plugin"],
+  "keywords": [
+    "terminus-plugin"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This was generated using https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/tools/xrdb2Xresources.py
from a xrdb file, which was generated by using https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/tools/iterm2xrdb
on https://github.com/chriskempson/base16-iterm2/blob/master/base16-default.dark.256.itermcolors

This is to address the first issue raised in #47.

The changes to the `package.json`s are done automatically by npm (I'm using npm v5). If you'd like to not include those changes, please let me know.

I've tested this out and it seems to work, however, it seems that terminus does not support 256 colors, because colors 17-21 appear as black/ blue (https://github.com/chriskempson/base16-shell#troubleshooting)