### PR TITLE
Fixed git-bash found

### DIFF
--- a/terminus-terminal/src/shells/gitBash.ts
+++ b/terminus-terminal/src/shells/gitBash.ts
@@ -23,7 +23,7 @@ export class GitBashShellProvider extends ShellProvider {
         }
 
         let gitBashPath = await new Promise<string>(resolve => {
-            let reg = new Registry({ hive: Registry.HKLM, key: '\\Software\\GitForWindows' })
+            let reg = new Registry({ hive: Registry.HKCU, key: '\\Software\\GitForWindows' })
             reg.get('InstallPath', (err, item) => {
                 if (err) {
                     resolve(null)


### PR DESCRIPTION
Since Windows Vista access to certain Registry Hives (HKEY_LOCAL_MACHINE or short HKLM for example) is restricted to processes that run in a security elevated context even if the user that starts the process is an admin. (https://www.npmjs.com/package/winreg)