### PR TITLE
Start an interactive logon shell for Git Bash

### DIFF
--- a/terminus-terminal/src/shells/gitBash.ts
+++ b/terminus-terminal/src/shells/gitBash.ts
@@ -41,6 +41,7 @@ export class GitBashShellProvider extends ShellProvider {
             id: 'git-bash',
             name: 'Git-Bash',
             command: path.join(gitBashPath, 'bin', 'bash.exe'),
+            args: [ '--login', '-i' ],
             env: {
                 TERM: 'cygwin',
             }


### PR DESCRIPTION
Provide additional arguments to `bash.exe` to get an interactive login shell. This ensures e.g. `.profile` and `.bash_profile` are sourced. As there’s no way to have an existing session under Windows, `--login` is mandatory. Each bash session must be started from scratch.

Fixes #105