### PR TITLE
feat(tab): enable cycle tab selection

### DIFF
--- a/terminus-core/src/configDefaults.yaml
+++ b/terminus-core/src/configDefaults.yaml
@@ -3,6 +3,7 @@ appearance:
   dockScreen: current
   dockFill: 50
   tabsLocation: top
+  cycleTabs: true
   theme: Standard
   frame: thin
   css: '/* * { color: blue !important; } */'

--- a/terminus-core/src/services/app.service.ts
+++ b/terminus-core/src/services/app.service.ts
@@ -3,6 +3,7 @@ import { Injectable, ComponentFactoryResolver, Injector, Optional } from '@angul
 import { DefaultTabProvider } from '../api/defaultTabProvider'
 import { BaseTabComponent } from '../components/baseTab.component'
 import { Logger, LogService } from '../services/log.service'
+import { ConfigService } from '../services/config.service'
 
 export declare type TabComponentType = new (...args: any[]) => BaseTabComponent
 
@@ -18,6 +19,7 @@ export class AppService {
     constructor (
         private componentFactoryResolver: ComponentFactoryResolver,
         @Optional() private defaultTabProvider: DefaultTabProvider,
+        private config: ConfigService,
         private injector: Injector,
         log: LogService,
     ) {
@@ -70,16 +72,24 @@ export class AppService {
     }
 
     nextTab () {
-        let tabIndex = this.tabs.indexOf(this.activeTab)
-        if (tabIndex < this.tabs.length - 1) {
-            this.selectTab(this.tabs[tabIndex + 1])
+        if (this.tabs.length > 1) {
+            let tabIndex = this.tabs.indexOf(this.activeTab)
+            if (tabIndex < this.tabs.length - 1) {
+                this.selectTab(this.tabs[tabIndex + 1])
+            } else if (this.config.store.appearance.cycleTabs) {
+                this.selectTab(this.tabs[0])
+            }
         }
     }
 
     previousTab () {
-        let tabIndex = this.tabs.indexOf(this.activeTab)
-        if (tabIndex > 0) {
-            this.selectTab(this.tabs[tabIndex - 1])
+        if (this.tabs.length > 1) {
+            let tabIndex = this.tabs.indexOf(this.activeTab)
+            if (tabIndex > 0) {
+                this.selectTab(this.tabs[tabIndex - 1])
+            } else if (this.config.store.appearance.cycleTabs) {
+                this.selectTab(this.tabs[this.tabs.length - 1])
+            }
         }
     }
 


### PR DESCRIPTION
- closes #258 

I took a stab myself for this feature, while I also have relatively high confidence PR is not feasible to be accepted. 

This PR exposes one more settings values to allow `cycle` tab selection, either next / previous tab hotkey will select to last / first tab if user specifies to.

point of consideration
1. may possible to control this behavior via plugin instead of core?
: I couldn't find relative interface support, but maybe I am lack of knowledge simply.

2. Is it feasible to expose under application settings, under `appearance`? 
: It isn't actually appearance but more about behavior, while current settings doesn't have specific category. Hotkey provider is managing assigned key combination, so picked current one instead.

3. Would it be better to have checkbox instead of radio?
: this may not be big deal (and could reuse all styles), but still this could be checkbox for boolean flag.