### PR TITLE
Fixed typo in SSH client's configuration window.

### DIFF
--- a/terminus-ssh/src/components/editConnectionModal.component.pug
+++ b/terminus-ssh/src/components/editConnectionModal.component.pug
@@ -18,7 +18,7 @@
         input.form-control(
             type='number',
             placeholder='22', 
-            [(ngModel)]='connection.post', 
+            [(ngModel)]='connection.port', 
         )
 
     .form-group


### PR DESCRIPTION
It looks like somebody misspelled "port", thus blocking the users from accessing SSH-servers that listen on non-default port.