### PR TITLE
Update popup to get rid of messy process identifiers

### DIFF
--- a/terminus-terminal/src/components/terminalTab.component.ts
+++ b/terminus-terminal/src/components/terminalTab.component.ts
@@ -479,7 +479,7 @@ export class TerminalTabComponent extends BaseTabComponent {
         if (children.length === 0) {
             return true
         }
-        return confirm(`"${children[0].command}" is still running. Close?`)
+        return confirm(`Tab has an active process. Close?`)
     }
 
     private setFontSize () {


### PR DESCRIPTION
`children[0].process` would show process identifiers like `s001` instead of a process name on an idling terminal. Changed close confirm message so that this doesn't happen.

I like the idea of showing the process when confirming, but I would change it to this until there's a way to reliably produce a "pretty" process name.