### PR TITLE
Restore Bash on Windows

### DIFF
--- a/terminus-terminal/src/shells/wsl.ts
+++ b/terminus-terminal/src/shells/wsl.ts
@@ -18,10 +18,24 @@ export class WSLShellProvider extends ShellProvider {
             return []
         }
 
+        const bashPath = `${process.env.windir}\\system32\\bash.exe`
         const wslPath = `${process.env.windir}\\system32\\wsl.exe`
         const wslConfigPath = `${process.env.windir}\\system32\\wslconfig.exe`
+
         if (!await fs.exists(wslPath)) {
-            return []
+            if (await fs.exists(bashPath)) {
+                return [{
+                    id: 'wsl',
+                    name: 'WSL / Bash on Windows',
+                    command: bashPath,
+                    env: {
+                        TERM: 'xterm-color',
+                        COLORTERM: 'truecolor',
+                    }
+                }]
+            } else {
+                return []
+            }
         }
 
         let lines = (await exec(`${wslConfigPath} /l`, { encoding: 'ucs2' }))[0].toString().split('\n').splice(1)


### PR DESCRIPTION
After Windows 10 Fall Creators Update, WSL started supporting Distros from Windows Store so for those who didn't update to Fall Creators Update don't support WSL distributions in Alpha 57. This should fix it and resolves #438 and #441