### PR TITLE
Feature/rename tab qol

### DIFF
--- a/terminus-core/src/components/renameTabModal.component.ts
+++ b/terminus-core/src/components/renameTabModal.component.ts
@@ -16,6 +16,7 @@ export class RenameTabModalComponent {
     ngOnInit () {
         setTimeout(() => {
             this.input.nativeElement.focus()
+            this.input.nativeElement.select()
         }, 250)
     }
 

--- a/terminus-core/src/components/tabHeader.component.ts
+++ b/terminus-core/src/components/tabHeader.component.ts
@@ -63,10 +63,6 @@ export class TabHeaderComponent {
     showRenameTabModal (): void {
         let modal = this.ngbModal.open(RenameTabModalComponent)
         modal.componentInstance.value = this.tab.customTitle || this.tab.title
-        setTimeout(() => {
-            const inputElement = modal.componentInstance.input.nativeElement as HTMLInputElement
-            inputElement.select()
-        }, 250)
         modal.result.then(result => {
             this.tab.setTitle(result)
             this.tab.customTitle = result

--- a/terminus-core/src/configDefaults.linux.yaml
+++ b/terminus-core/src/configDefaults.linux.yaml
@@ -11,6 +11,8 @@ hotkeys:
   toggle-last-tab:
     - ['Ctrl-A', 'A']
     - ['Ctrl-A', 'Ctrl-A']
+  rename-tab:
+    - 'Ctrl-Shift-R'
   next-tab:
     - 'Ctrl-Shift-ArrowRight'
     - ['Ctrl-A', 'N']

--- a/terminus-core/src/configDefaults.macos.yaml
+++ b/terminus-core/src/configDefaults.macos.yaml
@@ -8,6 +8,8 @@ hotkeys:
   close-tab:
     - '⌘-W'
   toggle-last-tab: []
+  rename-tab:
+    - 'Ctrl-Shift-R'
   next-tab:
     - 'Ctrl-Tab'
   previous-tab:

--- a/terminus-core/src/configDefaults.macos.yaml
+++ b/terminus-core/src/configDefaults.macos.yaml
@@ -9,7 +9,7 @@ hotkeys:
     - '⌘-W'
   toggle-last-tab: []
   rename-tab:
-    - 'Ctrl-Shift-R'
+    - '⌘-R'
   next-tab:
     - 'Ctrl-Tab'
   previous-tab:

--- a/terminus-core/src/configDefaults.windows.yaml
+++ b/terminus-core/src/configDefaults.windows.yaml
@@ -11,6 +11,8 @@ hotkeys:
   toggle-last-tab:
     - ['Ctrl-A', 'A']
     - ['Ctrl-A', 'Ctrl-A']
+  rename-tab:
+    - 'Ctrl-Shift-R'
   next-tab:
     - 'Ctrl-Shift-ArrowRight'
     - ['Ctrl-A', 'N']

--- a/terminus-core/src/services/hotkeys.service.ts
+++ b/terminus-core/src/services/hotkeys.service.ts
@@ -216,6 +216,10 @@ export class AppHotkeyProvider extends HotkeyProvider {
             name: 'Toggle fullscreen mode',
         },
         {
+            id: 'rename-tab',
+            name: 'Rename Tab',
+        },
+        {
             id: 'close-tab',
             name: 'Close tab',
         },

--- a/terminus-terminal/src/components/terminalTab.component.ts
+++ b/terminus-terminal/src/components/terminalTab.component.ts
@@ -264,9 +264,9 @@ export class TerminalTabComponent extends BaseTabComponent {
                     let wheelDeltaY = 0
 
                     if ('wheelDeltaY' in event) {
-                        wheelDeltaY = (event as MouseWheelEvent).wheelDeltaY
+                        wheelDeltaY = (event as MouseWheelEvent)['wheelDeltaY']
                     } else {
-                        wheelDeltaY = (event as MouseWheelEvent).deltaY
+                        wheelDeltaY = (event as MouseWheelEvent)['deltaY']
                     }
                     if (event.ctrlKey || event.metaKey) {
 


### PR DESCRIPTION
The functionality to rename a tab is not obvious, I didn't find it existed until i got into the source code.

This commit adds rename to the tab right click dialog, as well as adds a hotkey (defaults to CTRL+SHIFT+R) to improve QOL.

One final change was to automatically select the text in the input of the RenameTab dialog.

fixes #19