### PR TITLE
Change close behavior on MacOS

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -156,6 +156,11 @@ export class Window {
         this.window.on('leave-full-screen', () => this.window.webContents.send('host:window-leave-full-screen'))
 
         this.window.on('close', event => {
+            if (process.platform === 'darwin') {
+                event.preventDefault()
+                this.window.hide()
+                return
+            }
             if (!this.closing) {
                 event.preventDefault()
                 this.window.webContents.send('host:window-close-request')


### PR DESCRIPTION
On MacOS, the close button isn't actually supposed to quit the app, it should only hide it.
It should be changed so it's consisted with the platform