### PR TITLE
Remove name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "term",
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@types/electron-config": "^3.2.2",


### PR DESCRIPTION
Removed name because it's a monorepo and it conflicts with https://www.npmjs.com/package/term