### PR TITLE
added proc destruction on tab close (fixes #1261)

### DIFF
--- a/terminus-terminal/src/components/terminalTab.component.ts
+++ b/terminus-terminal/src/components/terminalTab.component.ts
@@ -97,5 +97,6 @@ export class TerminalTabComponent extends BaseTerminalTabComponent {
     ngOnDestroy () {
         this.homeEndSubscription.unsubscribe()
         super.ngOnDestroy()
+        this.session.destroy()
     }
 }


### PR DESCRIPTION
This resolves #1261, basically processes are being taken care of when a tab closes. 🙂 