### PR TITLE
Add a newline after banners

### DIFF
--- a/terminus-ssh/src/services/ssh.service.ts
+++ b/terminus-ssh/src/services/ssh.service.ts
@@ -132,7 +132,7 @@ export class SSHService {
             })
 
             ssh.on('banner', banner => {
-                log('Banner: ' + banner)
+                log('Banner: \n' + banner)
             })
 
             let agent: string = null


### PR DESCRIPTION
This is to prevent ASCII-art style banners from getting messed up by the offset of the 'Banner: ' text such as in [this image](https://i.imgur.com/K78mEus.png).

Apologies if this code doesn't work, I'm not exactly good with TypeScript.