### PR TITLE
Update container styles to restore scrolling settings panes

### DIFF
--- a/terminus-core/src/components/appRoot.component.scss
+++ b/terminus-core/src/components/appRoot.component.scss
@@ -18,6 +18,7 @@ $tab-border-radius: 4px;
 
 
 .content {
+    height: 100%;
     flex: auto;
     display: flex;
     flex-direction: column-reverse;

--- a/terminus-settings/src/components/settingsTab.deep.component.css
+++ b/terminus-settings/src/components/settingsTab.deep.component.css
@@ -1,12 +1,12 @@
 :host /deep/ ngb-tabset {
     flex: auto;
     display: flex;
+    height: 100%;
 }
 
 :host /deep/ ngb-tabset > .nav {
-    display: flex;
-    flex-direction: column;
-    flex: none;
+    display: block;
+    overflow-y: auto;
 }
 
 :host /deep/ ngb-tabset > .tab-content {


### PR DESCRIPTION
**Fixes #1439**

Make a number of style changes to ensure that the settings panels and associated navigation are scrollable.