### PR TITLE
Issue #1494 - Fix middle click for closing tabs

### DIFF
--- a/terminus-core/src/components/tabHeader.component.ts
+++ b/terminus-core/src/components/tabHeader.component.ts
@@ -78,10 +78,19 @@ export class TabHeaderComponent {
         this.showRenameTabModal()
     }
 
-    @HostListener('auxclick', ['$event']) async onAuxClick ($event: MouseEvent) {
+    @HostListener('mousedown', ['$event']) async onMouseDown ($event: MouseEvent) {
+        if ($event.which === 2) {
+            $event.preventDefault();
+        }
+    }
+
+    @HostListener('mouseup', ['$event']) async onMouseUp ($event: MouseEvent) {
         if ($event.which === 2) {
             this.app.closeTab(this.tab, true)
         }
+    }
+
+    @HostListener('auxclick', ['$event']) async onAuxClick ($event: MouseEvent) {
         if ($event.which === 3) {
             $event.preventDefault()
 

--- a/terminus-core/src/components/tabHeader.component.ts
+++ b/terminus-core/src/components/tabHeader.component.ts
@@ -80,7 +80,7 @@ export class TabHeaderComponent {
 
     @HostListener('mousedown', ['$event']) async onMouseDown ($event: MouseEvent) {
         if ($event.which === 2) {
-            $event.preventDefault();
+            $event.preventDefault()
         }
     }
 


### PR DESCRIPTION
Fixes issue #1494 

Feels like there should have been another way to disable the scrolling behavior but I couldn't find one, but this seems to work well.