### PR TITLE
Issue #1549 Add option to disable tab restore on startup

### DIFF
--- a/terminus-core/src/services/app.service.ts
+++ b/terminus-core/src/services/app.service.ts
@@ -71,18 +71,27 @@ export class AppService {
         private tabsService: TabsService,
     ) {
         if (hostApp.getWindow().id === 1) {
-            this.tabRecovery.recoverTabs().then(tabs => {
-                for (const tab of tabs) {
-                    this.openNewTabRaw(tab.type, tab.options)
-                }
-                this.tabsChanged$.subscribe(() => {
-                    tabRecovery.saveTabs(this.tabs)
+            if (config.store.terminal.recoverTabs) {
+                this.tabRecovery.recoverTabs().then(tabs => {
+                    for (const tab of tabs) {
+                        this.openNewTabRaw(tab.type, tab.options)
+                    }
+                    this.startTabStorage()
                 })
-                setInterval(() => {
-                    tabRecovery.saveTabs(this.tabs)
-                }, 30000)
-            })
+            } else {
+                /** Continue to store the tabs even if the setting is currently off */
+                this.startTabStorage()
+            }
         }
+    }
+
+    startTabStorage() {
+        this.tabsChanged$.subscribe(() => {
+            this.tabRecovery.saveTabs(this.tabs)
+        })
+        setInterval(() => {
+            this.tabRecovery.saveTabs(this.tabs)
+        }, 30000)
     }
 
     addTabRaw (tab: BaseTabComponent) {

--- a/terminus-terminal/src/components/terminalSettingsTab.component.pug
+++ b/terminus-terminal/src/components/terminalSettingsTab.component.pug
@@ -68,6 +68,15 @@ h3.mb-3 Terminal
 
 .form-line
     .header
+        .title Restore terminal tabs on app start
+            
+    toggle(
+        [(ngModel)]='config.store.terminal.recoverTabs',
+        (ngModelChange)='config.save()',
+    )
+
+.form-line
+    .header
         .title Bracketed paste (requires shell support)
         .description Prevents accidental execution of pasted commands
     toggle(

--- a/terminus-terminal/src/config.ts
+++ b/terminus-terminal/src/config.ts
@@ -59,6 +59,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             environment: {},
             profiles: [],
             useConPTY: true,
+            recoverTabs: true,
         },
     }
 


### PR DESCRIPTION
Add option to disable tab recovery on startup (but still saving the current tab config)