### PR TITLE
Catch errors when trying to derive CWD in Linux

### DIFF
--- a/terminus-terminal/src/services/sessions.service.ts
+++ b/terminus-terminal/src/services/sessions.service.ts
@@ -294,8 +294,8 @@ export class Session extends BaseSession {
             try {
                 return await fs.readlink(`/proc/${this.truePID}/cwd`)
             } catch (exc) {
-              console.error(exc)
-              return null
+                console.error(exc)
+                return null
             }
         }
         if (process.platform === 'win32') {

--- a/terminus-terminal/src/services/sessions.service.ts
+++ b/terminus-terminal/src/services/sessions.service.ts
@@ -291,7 +291,12 @@ export class Session extends BaseSession {
             return cwd
         }
         if (process.platform === 'linux') {
-            return fs.readlink(`/proc/${this.truePID}/cwd`)
+            try {
+                return await fs.readlink(`/proc/${this.truePID}/cwd`)
+            } catch (exc) {
+              console.error(exc)
+              return null
+            }
         }
         if (process.platform === 'win32') {
             if (!this.guessedCWD) {


### PR DESCRIPTION
When the process it tries to read the working dir from has exited, then "/proc/PID/cwd" is an invalid link and fs.readlink() will reject its promise with an error.

This results in the terminal "new tab" and "new pane" buttons stopping working, which is very disruptive :cry: 

This commit makes sure that the "new tab" and "new pane" buttons keep working, whatever happens.

fixes #1576