### PR TITLE
narrow down the margin of remote ssh ternimal to 5px

### DIFF
--- a/terminus-ssh/src/components/sshTab.component.scss
+++ b/terminus-ssh/src/components/sshTab.component.scss
@@ -10,7 +10,7 @@
         position: relative;
         display: block;
         overflow: hidden;
-        margin: 15px;
+        margin: 5px;
     }
 
     .ssh-tab-toolbar {

--- a/terminus-ssh/src/components/sshTab.component.ts
+++ b/terminus-ssh/src/components/sshTab.component.ts
@@ -8,6 +8,7 @@ import { SSHPortForwardingModalComponent } from './sshPortForwardingModal.compon
 
 /** @hidden */
 @Component({
+    selector: 'ssh-tab',
     template: BaseTerminalTabComponent.template + require<string>('./sshTab.component.pug'),
     styles: [require('./sshTab.component.scss'), ...BaseTerminalTabComponent.styles],
     animations: BaseTerminalTabComponent.animations,

--- a/terminus-terminal/src/components/terminalTab.component.scss
+++ b/terminus-terminal/src/components/terminalTab.component.scss
@@ -13,7 +13,7 @@
         position: relative;
         display: block;
         overflow: hidden;
-        margin: 15px;
+        margin: 5px;
         transition: opacity ease-out 0.25s;
         opacity: 0;
 


### PR DESCRIPTION
For remote ssh tabs, the margins of terminal tab is more wide than local ssh tabs.