### PR TITLE
Have multiple recent connections in history instead of just one

### DIFF
--- a/terminus-ssh/src/components/sshModal.component.pug
+++ b/terminus-ssh/src/components/sshModal.component.pug
@@ -1,22 +1,25 @@
 .modal-body
     input.form-control(
-        type='text', 
-        [(ngModel)]='quickTarget', 
-        autofocus, 
-        placeholder='Quick connect: [user@]host[:port]', 
+        type='text',
+        [(ngModel)]='quickTarget',
+        autofocus,
+        placeholder='Quick connect: [user@]host[:port]',
         (ngModelChange)='refresh()',
         (keyup.enter)='quickConnect()'
     )
-    
-    .list-group.mt-3(*ngIf='lastConnection')
-        a.list-group-item.list-group-item-action.d-flex.align-items-center((click)='connect(lastConnection)') 
+
+    .list-group.mt-3(*ngIf='recentConnections')
+        a.list-group-item.list-group-item-action.d-flex.align-items-center(
+            *ngFor='let connection of recentConnections',
+            (click)='connect(connection)'
+        )
             i.fas.fa-fw.fa-history
-            .mr-auto {{lastConnection.name}}
-            button.btn.btn-outline-danger.btn-sm((click)='clearLastConnection(); $event.stopPropagation()')
+            .mr-auto {{connection.name}}
+            button.btn.btn-outline-danger.btn-sm((click)='clearConnection(connection); $event.stopPropagation()')
                 i.fas.fa-trash
-    
+
     .list-group.mt-3.connections-list(*ngIf='childGroups.length')
-        ng-container(*ngFor='let group of childGroups') 
+        ng-container(*ngFor='let group of childGroups')
             .list-group-item.list-group-item-action.d-flex.align-items-center(
                 (click)='groupCollapsed[group.name] = !groupCollapsed[group.name]'
             )
@@ -25,8 +28,8 @@
                 .ml-2 {{group.name || "Ungrouped"}}
             ng-container(*ngIf='!groupCollapsed[group.name]')
                 .list-group-item.list-group-item-action.pl-5.d-flex.align-items-center(
-                    *ngFor='let connection of group.connections', 
+                    *ngFor='let connection of group.connections',
                     (click)='connect(connection)'
-                ) 
+                )
                     .mr-2 {{connection.name}}
                     .text-muted {{connection.host}}

--- a/terminus-ssh/src/components/sshModal.component.ts
+++ b/terminus-ssh/src/components/sshModal.component.ts
@@ -16,7 +16,7 @@ export class SSHModalComponent {
     connections: SSHConnection[]
     childFolders: SSHConnectionGroup[]
     quickTarget: string
-    lastConnection: SSHConnection|null = null
+    recentConnections: SSHConnection[]
     childGroups: SSHConnectionGroup[]
     groupCollapsed: {[id: string]: boolean} = {}
 
@@ -30,9 +30,7 @@ export class SSHModalComponent {
 
     ngOnInit () {
         this.connections = this.config.store.ssh.connections
-        if (window.localStorage.lastConnection) {
-            this.lastConnection = JSON.parse(window.localStorage.lastConnection)
-        }
+        this.recentConnections = this.config.store.ssh.recentConnections
         this.refresh()
     }
 
@@ -55,13 +53,21 @@ export class SSHModalComponent {
             user,
             port,
         }
-        window.localStorage.lastConnection = JSON.stringify(connection)
+        this.recentConnections.unshift(connection)
+        if (this.recentConnections.length > 5) {
+            this.recentConnections.pop()
+        }
+        this.config.store.ssh.recentConnections = this.recentConnections
+        this.config.save()
         this.connect(connection)
     }
 
-    clearLastConnection () {
-        window.localStorage.lastConnection = null
-        this.lastConnection = null
+    clearConnection (connection) {
+        this.recentConnections = this.recentConnections.filter(function (el) {
+            return el === connection
+        })
+        this.config.store.ssh.recentConnections = this.recentConnections
+        this.config.save()
     }
 
     async connect (connection: SSHConnection) {

--- a/terminus-ssh/src/components/sshModal.component.ts
+++ b/terminus-ssh/src/components/sshModal.component.ts
@@ -64,7 +64,7 @@ export class SSHModalComponent {
 
     clearConnection (connection) {
         this.recentConnections = this.recentConnections.filter(function (el) {
-            return el === connection
+            return el !== connection
         })
         this.config.store.ssh.recentConnections = this.recentConnections
         this.config.save()

--- a/terminus-ssh/src/config.ts
+++ b/terminus-ssh/src/config.ts
@@ -5,6 +5,7 @@ export class SSHConfigProvider extends ConfigProvider {
     defaults = {
         ssh: {
             connections: [],
+            recentConnections: [],
             options: {
             },
         },


### PR DESCRIPTION
Hi,  

I thought this would be useful since a user may want to connect quickly to multiple machines without having to save them, due to IP address changes or for any other reason.  
I put an arbitrary number of 5 recent connections, but I think it'd be better if it was a configuration option.  
It's just a suggestion, you can totally disregard this PR if you don't agree with it.  

Cheers