### PR TITLE
Fix: open serial will crash when the node lastSerialConnection not exsist

### DIFF
--- a/terminus-serial/src/services/serial.service.ts
+++ b/terminus-serial/src/services/serial.service.ts
@@ -64,7 +64,7 @@ export class SerialService {
 
     async showConnectionSelector (): Promise<void> {
         const options: SelectorOption<void>[] = []
-        const lastConnection = JSON.parse(window.localStorage.lastSerialConnection)
+        const lastConnection = window.localStorage.lastSerialConnection?JSON.parse(window.localStorage.lastSerialConnection):null
         const foundPorts = await this.listPorts()
 
         if (lastConnection) {


### PR DESCRIPTION
```log
ERROR Error: Uncaught (in promise): SyntaxError: Unexpected token u in JSON at position 0
SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at SerialService.<anonymous> (E:\Software\Portable…l\dist\index.js:648)
    at Generator.next (<anonymous>)
    at E:\Software\Portable…l\dist\index.js:165
    at new ZoneAwarePromise (E:\Software\Portable…js\dist\zone.js:913)
    at __awaiter (E:\Software\Portable…l\dist\index.js:161)
    at SerialService.showConnectionSelector (E:\Software\Portable…l\dist\index.js:646)
    at ButtonProvider.activate (E:\Software\Portable…l\dist\index.js:941)
    at ButtonProvider.<anonymous> (E:\Software\Portable…l\dist\index.js:950)
    at Generator.next (<anonymous>)
    at E:\Software\Portable…l\dist\index.js:165
    at new ZoneAwarePromise (E:\Software\Portable…js\dist\zone.js:913)
    at __awaiter (E:\Software\Portable…l\dist\index.js:161)
    at Object.click (E:\Software\Portable…l\dist\index.js:949)
    at Object.eval [as handleEvent] (AppRootComponent.ngfactory.js:366)
    at Object.handleEvent (E:\Software\Portable…s\core.umd.js:30959)
    at Object.handleEvent (E:\Software\Portable…s\core.umd.js:31504)
    at dispatchEvent (E:\Software\Portable…s\core.umd.js:21508)
    at E:\Software\Portable…s\core.umd.js:30168
    at HTMLButtonElement.<anonymous> (E:\Software\Portable…-browser.umd.js:758)
    at ZoneDelegate.invokeTask (E:\Software\Portable…js\dist\zone.js:421)
    at Object.onInvokeTask (E:\Software\Portable…s\core.umd.js:27916)
    at ZoneDelegate.invokeTask (E:\Software\Portable…js\dist\zone.js:420)
    at Zone.runTask (E:\Software\Portable…js\dist\zone.js:188)
    at ZoneTask.invokeTask [as invoke] (E:\Software\Portable…js\dist\zone.js:503)
    at invokeTask (E:\Software\Portable…s\dist\zone.js:1671)
    at HTMLButtonElement.globalZoneAwareCallback (E:\Software\Portable…s\dist\zone.js:1697)
    at HTMLButtonElement.sentryWrapped (E:\Software\Portable…dist\sentry.js:1882)
    at resolvePromise (E:\Software\Portable…js\dist\zone.js:832)
    at new ZoneAwarePromise (E:\Software\Portable…js\dist\zone.js:916)
    at __awaiter (E:\Software\Portable…l\dist\index.js:161)
    at SerialService.showConnectionSelector (E:\Software\Portable…l\dist\index.js:646)
    at ButtonProvider.activate (E:\Software\Portable…l\dist\index.js:941)
    at ButtonProvider.<anonymous> (E:\Software\Portable…l\dist\index.js:950)
    at Generator.next (<anonymous>)
    at E:\Software\Portable…l\dist\index.js:165
    at new ZoneAwarePromise (E:\Software\Portable…js\dist\zone.js:913)
    at __awaiter (E:\Software\Portable…l\dist\index.js:161)
    at Object.click (E:\Software\Portable…l\dist\index.js:949)
    at Object.eval [as handleEvent] (AppRootComponent.ngfactory.js:366)
    at Object.handleEvent (E:\Software\Portable…s\core.umd.js:30959)
    at Object.handleEvent (E:\Software\Portable…s\core.umd.js:31504)
    at dispatchEvent (E:\Software\Portable…s\core.umd.js:21508)
    at E:\Software\Portable…s\core.umd.js:30168
    at HTMLButtonElement.<anonymous> (E:\Software\Portable…-browser.umd.js:758)
    at ZoneDelegate.invokeTask (E:\Software\Portable…js\dist\zone.js:421)
    at Object.onInvokeTask (E:\Software\Portable…s\core.umd.js:27916)
    at ZoneDelegate.invokeTask (E:\Software\Portable…js\dist\zone.js:420)
    at Zone.runTask (E:\Software\Portable…js\dist\zone.js:188)
    at ZoneTask.invokeTask [as invoke] (E:\Software\Portable…js\dist\zone.js:503)
    at invokeTask (E:\Software\Portable…s\dist\zone.js:1671)
    at HTMLButtonElement.globalZoneAwareCallback (E:\Software\Portable…s\dist\zone.js:1697)
    at HTMLButtonElement.sentryWrapped (E:\Software\Portable…dist\sentry.js:1882)
```