### PR TITLE
Add dock always on top setting

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -193,8 +193,13 @@ export class Window {
                     this.window.focus()
                 })
             } else {
-                // docked, visible
-                this.window.hide()
+                if (this.configStore.appearance?.dockAlwaysOnTop) {           
+                    // docked, visible, on top
+                    this.window.hide()
+                } else {
+                    // docked, visible, not on top
+                    this.window.focus()
+                }
             }
         }
     }

--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -193,7 +193,7 @@ export class Window {
                     this.window.focus()
                 })
             } else {
-                if (this.configStore.appearance?.dockAlwaysOnTop) {           
+                if (this.configStore.appearance?.dockAlwaysOnTop) {
                     // docked, visible, on top
                     this.window.hide()
                 } else {

--- a/terminus-core/src/configDefaults.yaml
+++ b/terminus-core/src/configDefaults.yaml
@@ -2,6 +2,7 @@ appearance:
   dock: off
   dockScreen: current
   dockFill: 0.5
+  dockAlwaysOnTop: true
   tabsLocation: top
   cycleTabs: true
   theme: Standard

--- a/terminus-core/src/services/docking.service.ts
+++ b/terminus-core/src/services/docking.service.ts
@@ -53,7 +53,9 @@ export class DockingService {
             newBounds.y = display.bounds.y
         }
 
-        this.hostApp.setAlwaysOnTop(true)
+        const alwaysOnTop = this.config.store.appearance.dockAlwaysOnTop
+
+        this.hostApp.setAlwaysOnTop(alwaysOnTop)
         setImmediate(() => {
             this.hostApp.setBounds(newBounds)
         })

--- a/terminus-settings/src/components/settingsTab.component.pug
+++ b/terminus-settings/src/components/settingsTab.component.pug
@@ -209,6 +209,15 @@ ngb-tabset.vertical(type='pills', [activeId]='activeTab')
 
             .form-line(*ngIf='config.store.appearance.dock != "off"')
                 .header
+                    .title Dock always on top
+                    .description Keep docked terminal always on top
+                toggle(
+                    [(ngModel)]='config.store.appearance.dockAlwaysOnTop',
+                    (ngModelChange)='config.save(); docking.dock()',
+                )
+
+            .form-line(*ngIf='config.store.appearance.dock != "off"')
+                .header
                     .title Docked terminal size
                 input(
                     type='range',


### PR DESCRIPTION
Adds a dock "always on top" toggle.

This possibly fixes #1894

This also tweaks the behavior of the toggle-window shortcut so it behaves as expected
(brings unfocused docked window to top, but still closes unfocused docked window that is already on top), 