### PR TITLE
Add dock hide on blur option

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -103,6 +103,12 @@ export class Window {
             }
         })
 
+        this.window.on('blur',() => {
+            if (this.configStore.appearance?.dockHideOnBlur) {
+                this.hide()
+            }
+        })
+
         this.window.loadURL(`file://${app.getAppPath()}/dist/index.html?${this.window.id}`, { extraHeaders: 'pragma: no-cache\n' })
 
         if (process.platform !== 'darwin') {

--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -103,7 +103,7 @@ export class Window {
             }
         })
 
-        this.window.on('blur',() => {
+        this.window.on('blur', () => {
             if (this.configStore.appearance?.dockHideOnBlur) {
                 this.hide()
             }

--- a/terminus-core/src/configDefaults.yaml
+++ b/terminus-core/src/configDefaults.yaml
@@ -2,6 +2,7 @@ appearance:
   dock: off
   dockScreen: current
   dockFill: 0.5
+  dockHideOnBlur: false
   tabsLocation: top
   cycleTabs: true
   theme: Standard

--- a/terminus-settings/src/components/settingsTab.component.pug
+++ b/terminus-settings/src/components/settingsTab.component.pug
@@ -219,6 +219,15 @@ ngb-tabset.vertical(type='pills', [activeId]='activeTab')
                     step='0.01'
                 )
 
+            .form-line(*ngIf='config.store.appearance.dock != "off"')
+                .header
+                    .title Hide dock on blur
+                    .description Hides the docked terminal when you click away.
+                toggle(
+                    [(ngModel)]='config.store.appearance.dockHideOnBlur',
+                    (ngModelChange)='config.save(); ',
+                )
+
             .form-line
                 .header
                     .title Debugging


### PR DESCRIPTION
Adds an option to hide the docked terminal when you click away from the window

This possibly fixes #1894