### PR TITLE
Add possibility to configure always enabled regex

### DIFF
--- a/terminus-terminal/src/components/searchPanel.component.pug
+++ b/terminus-terminal/src/components/searchPanel.component.pug
@@ -26,7 +26,7 @@ button.btn.btn-link(
 .mr-2
 
 button.btn.btn-link(
-    (click)='options.caseSensitive = !options.caseSensitive',
+    (click)='options.caseSensitive = !options.caseSensitive; saveSearchOptions()',
     [class.active]='options.caseSensitive',
     ngbTooltip='Case sensitivity',
     placement='bottom'
@@ -34,14 +34,14 @@ button.btn.btn-link(
     i.fa.fa-fw.fa-font
 
 button.btn.btn-link(
-    (click)='options.regex = !options.regex',
+    (click)='options.regex = !options.regex; saveSearchOptions()',
     [class.active]='options.regex',
     ngbTooltip='Regular expression',
     placement='bottom'
 )
     i.fa.fa-fw.fa-asterisk
 button.btn.btn-link(
-    (click)='options.wholeWord = !options.wholeWord',
+    (click)='options.wholeWord = !options.wholeWord; saveSearchOptions()',
     [class.active]='options.wholeWord',
     ngbTooltip='Whole word',
     placement='bottom'

--- a/terminus-terminal/src/components/searchPanel.component.ts
+++ b/terminus-terminal/src/components/searchPanel.component.ts
@@ -14,7 +14,7 @@ export class SearchPanelComponent {
     notFound = false
     options: SearchOptions = {
         incremental: true,
-        ...this.config.store.terminal.searchOptions
+        ...this.config.store.terminal.searchOptions,
     }
 
     @Output() close = new EventEmitter()
@@ -28,7 +28,7 @@ export class SearchPanelComponent {
         this.notFound = false
         this.findPrevious(true)
     }
-    
+
     findNext (incremental = false): void {
         if (!this.query) {
             return
@@ -48,12 +48,12 @@ export class SearchPanelComponent {
             this.toastr.error('Not found')
         }
     }
-    
+
     saveSearchOptions (): void {
-        this.config.store.terminal.searchOptions.regex = this.options.regex;
-        this.config.store.terminal.searchOptions.caseSensitive = this.options.caseSensitive;
-        this.config.store.terminal.searchOptions.wholeWord = this.options.wholeWord;
-        
-        this.config.save();
+        this.config.store.terminal.searchOptions.regex = this.options.regex
+        this.config.store.terminal.searchOptions.caseSensitive = this.options.caseSensitive
+        this.config.store.terminal.searchOptions.wholeWord = this.options.wholeWord
+
+        this.config.save()
     }
 }

--- a/terminus-terminal/src/components/searchPanel.component.ts
+++ b/terminus-terminal/src/components/searchPanel.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core'
 import { ToastrService } from 'ngx-toastr'
 import { Frontend, SearchOptions } from '../frontends/frontend'
-import {ConfigService} from "terminus-core";
+import { ConfigService } from 'terminus-core'
 
 @Component({
     selector: 'search-panel',

--- a/terminus-terminal/src/components/searchPanel.component.ts
+++ b/terminus-terminal/src/components/searchPanel.component.ts
@@ -14,7 +14,7 @@ export class SearchPanelComponent {
     notFound = false
     options: SearchOptions = {
         incremental: true,
-        regex: this.config.store.terminal.searchRegexAlwaysEnabled,
+        ...this.config.store.terminal.searchOptions
     }
 
     @Output() close = new EventEmitter()
@@ -28,7 +28,7 @@ export class SearchPanelComponent {
         this.notFound = false
         this.findPrevious(true)
     }
-
+    
     findNext (incremental = false): void {
         if (!this.query) {
             return
@@ -47,5 +47,13 @@ export class SearchPanelComponent {
             this.notFound = true
             this.toastr.error('Not found')
         }
+    }
+    
+    saveSearchOptions (): void {
+        this.config.store.terminal.searchOptions.regex = this.options.regex;
+        this.config.store.terminal.searchOptions.caseSensitive = this.options.caseSensitive;
+        this.config.store.terminal.searchOptions.wholeWord = this.options.wholeWord;
+        
+        this.config.save();
     }
 }

--- a/terminus-terminal/src/components/searchPanel.component.ts
+++ b/terminus-terminal/src/components/searchPanel.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core'
 import { ToastrService } from 'ngx-toastr'
 import { Frontend, SearchOptions } from '../frontends/frontend'
+import {ConfigService} from "terminus-core";
 
 @Component({
     selector: 'search-panel',
@@ -13,12 +14,14 @@ export class SearchPanelComponent {
     notFound = false
     options: SearchOptions = {
         incremental: true,
+        regex: this.config.store.terminal.searchRegexAlwaysEnabled,
     }
 
     @Output() close = new EventEmitter()
 
     constructor (
         private toastr: ToastrService,
+        public config: ConfigService,
     ) { }
 
     onQueryChange (): void {

--- a/terminus-terminal/src/components/terminalSettingsTab.component.pug
+++ b/terminus-terminal/src/components/terminalSettingsTab.component.pug
@@ -116,6 +116,14 @@ h3.mb-3 Terminal
         [(ngModel)]='config.store.terminal.scrollOnInput',
         (ngModelChange)='config.save()',
     )
+    
+.form-line
+    .header
+        .title Regex in search always enabled
+    toggle(
+        [(ngModel)]='config.store.terminal.searchRegexAlwaysEnabled',
+        (ngModelChange)='config.save()',
+    )
 
 .form-line
     .header

--- a/terminus-terminal/src/components/terminalSettingsTab.component.pug
+++ b/terminus-terminal/src/components/terminalSettingsTab.component.pug
@@ -119,14 +119,6 @@ h3.mb-3 Terminal
     
 .form-line
     .header
-        .title Regex in search always enabled
-    toggle(
-        [(ngModel)]='config.store.terminal.searchRegexAlwaysEnabled',
-        (ngModelChange)='config.save()',
-    )
-
-.form-line
-    .header
         .title Use Alt key as the Meta key
         .description Lets the shell handle Meta key instead of OS
     toggle(

--- a/terminus-terminal/src/config.ts
+++ b/terminus-terminal/src/config.ts
@@ -65,6 +65,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             recoverTabs: true,
             warnOnMultilinePaste: true,
             showDefaultProfiles: true,
+            searchRegexAlwaysEnabled: false,
         },
     }
 

--- a/terminus-terminal/src/config.ts
+++ b/terminus-terminal/src/config.ts
@@ -66,6 +66,11 @@ export class TerminalConfigProvider extends ConfigProvider {
             warnOnMultilinePaste: true,
             showDefaultProfiles: true,
             searchRegexAlwaysEnabled: false,
+            searchOptions: {
+                regex: false,
+                wholeWord: false,
+                caseSensitive: false
+            }
         },
     }
 

--- a/terminus-terminal/src/config.ts
+++ b/terminus-terminal/src/config.ts
@@ -69,8 +69,8 @@ export class TerminalConfigProvider extends ConfigProvider {
             searchOptions: {
                 regex: false,
                 wholeWord: false,
-                caseSensitive: false
-            }
+                caseSensitive: false,
+            },
         },
     }
 


### PR DESCRIPTION
Hello,

When I want to copy something from terminal (like a part of some output) I always use regex in search.
I believe many people also does this. 

I thought it'd be really nice to be able to configure regex in search so it's always enabled. 