### PR TITLE
feat: Add copy button to ssh connection

### DIFF
--- a/terminus-ssh/src/components/sshSettingsTab.component.pug
+++ b/terminus-ssh/src/components/sshSettingsTab.component.pug
@@ -20,6 +20,8 @@ h3 Connections
                 .mr-auto
                     div {{connection.name}}
                     .text-muted {{connection.host}}
+                button.btn.btn-outline-info.ml-1((click)='$event.stopPropagation(); copyConnection(connection)')
+                    i.fas.fa-copy
                 button.btn.btn-outline-danger.ml-1((click)='$event.stopPropagation(); deleteConnection(connection)')
                     i.fas.fa-trash
 

--- a/terminus-ssh/src/components/sshSettingsTab.component.ts
+++ b/terminus-ssh/src/components/sshSettingsTab.component.ts
@@ -46,6 +46,18 @@ export class SSHSettingsTabComponent {
         })
     }
 
+    copyConnection (connection) {
+        connection.name += ' Copy'
+        const modal = this.ngbModal.open(EditConnectionModalComponent)
+        modal.componentInstance.connection = connection
+        modal.result.then(result => {
+            this.connections.push(result)
+            this.config.store.ssh.connections = this.connections
+            this.config.save()
+            this.refresh()
+        })
+    }
+
     editConnection (connection: SSHConnection) {
         const modal = this.ngbModal.open(EditConnectionModalComponent, { size: 'lg' })
         modal.componentInstance.connection = Object.assign({}, connection)

--- a/terminus-ssh/src/components/sshSettingsTab.component.ts
+++ b/terminus-ssh/src/components/sshSettingsTab.component.ts
@@ -46,7 +46,7 @@ export class SSHSettingsTabComponent {
         })
     }
 
-    copyConnection (connection) {
+    copyConnection (connection: SSHConnection) {
         const modal = this.ngbModal.open(EditConnectionModalComponent)
         modal.componentInstance.connection = Object.assign({
             name: `${name} Copy`,

--- a/terminus-ssh/src/components/sshSettingsTab.component.ts
+++ b/terminus-ssh/src/components/sshSettingsTab.component.ts
@@ -47,9 +47,8 @@ export class SSHSettingsTabComponent {
     }
 
     copyConnection (connection) {
-        connection.name += ' Copy'
         const modal = this.ngbModal.open(EditConnectionModalComponent)
-        modal.componentInstance.connection = connection
+        modal.componentInstance.connection = Object.assign({name: name + ' Copy'}, connection)
         modal.result.then(result => {
             this.connections.push(result)
             this.config.store.ssh.connections = this.connections

--- a/terminus-ssh/src/components/sshSettingsTab.component.ts
+++ b/terminus-ssh/src/components/sshSettingsTab.component.ts
@@ -48,7 +48,9 @@ export class SSHSettingsTabComponent {
 
     copyConnection (connection) {
         const modal = this.ngbModal.open(EditConnectionModalComponent)
-        modal.componentInstance.connection = Object.assign({name: name + ' Copy'}, connection)
+        modal.componentInstance.connection = Object.assign({
+            name: name + ' Copy'
+        }, connection)
         modal.result.then(result => {
             this.connections.push(result)
             this.config.store.ssh.connections = this.connections

--- a/terminus-ssh/src/components/sshSettingsTab.component.ts
+++ b/terminus-ssh/src/components/sshSettingsTab.component.ts
@@ -49,7 +49,7 @@ export class SSHSettingsTabComponent {
     copyConnection (connection) {
         const modal = this.ngbModal.open(EditConnectionModalComponent)
         modal.componentInstance.connection = Object.assign({
-            name: name + ' Copy'
+            name: `${name} Copy`,
         }, connection)
         modal.result.then(result => {
             this.connections.push(result)


### PR DESCRIPTION
I have a lot of SSH connection profiles, but by now I need to add them one by one. 

But in fact, all the profiles have some common fields like username, password, private key and even login scripts. 

This PR adds a copy button to add a new connection based on the existing connection profile.