### PR TITLE
Update "maximized" icon to be more consistent with standard Windows UI

### DIFF
--- a/terminus-core/src/components/windowControls.component.pug
+++ b/terminus-core/src/components/windowControls.component.pug
@@ -10,7 +10,7 @@ button.btn.btn-secondary.btn-maximize((click)='hostWindow.toggleMaximize()', *ng
 
 button.btn.btn-secondary.btn-maximize((click)='hostWindow.toggleMaximize()', *ngIf='hostWindow.isMaximized()')
     svg(version='1.1', width='10', height='10', viewBox='0 0 512 512')
-        path(d="M464 0H144c-26.5 0-48 21.5-48 48v48H48c-26.5 0-48 21.5-48 48v320c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h48c26.5 0 48-21.5 48-48V48c0-26.5-21.5-48-48-48zM32 144c0-8.8 7.2-16 16-16h320c8.8 0 16 7.2 16 16v80H32v-80zm352 320c0 8.8-7.2 16-16 16H48c-8.8 0-16-7.2-16-16V256h352v208zm96-96c0 8.8-7.2 16-16 16h-48V144c0-26.5-21.5-48-48-48H128V48c0-8.8 7.2-16 16-16h320c8.8 0 16 7.2 16 16v320z")
+        path(d="M464 0H144c-26.5 0-48 21.5-48 48v48H48c-26.5 0-48 21.5-48 48v320c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h48c26.5 0 48-21.5 48-48V48c0-26.5-21.5-48-48-48zM32 144c0-8.8 7.2-16 16-16h320c8.8 0 16 7.2 16 16v320c0 8.8-7.2 16-16 16H48c-8.8 0-16-7.2-16-16v-80zm448 224c0 8.8-7.2 16-16 16h-48V144c0-26.5-21.5-48-48-48H128V48c0-8.8 7.2-16 16-16h320c8.8 0 16 7.2 16 16v320z")
 
 button.btn.btn-secondary.btn-close(
     (click)='closeWindow()'


### PR DESCRIPTION
Thanks for fixing my issue https://github.com/Eugeny/terminus/issues/2712! I noticed that the new icon has an additional horizontal bar which makes it look quite different from most Windows applications. This PR removes the bar to make the icon more closely match the way almost all Windows apps look.

Before:
![image](https://user-images.githubusercontent.com/2292715/123728769-d90f0680-d861-11eb-84af-13034d9df74d.png)

After:
![image](https://user-images.githubusercontent.com/2292715/123728851-0065d380-d862-11eb-88e0-3431741747b5.png)

Example from Windows 10 File Explorer:
![image](https://user-images.githubusercontent.com/2292715/123728913-1a9fb180-d862-11eb-99cf-840da366a329.png)
