### PR TITLE
fix: adjust ssh config time resolution

### DIFF
--- a/tabby-electron/src/sshImporters.ts
+++ b/tabby-electron/src/sshImporters.ts
@@ -219,7 +219,12 @@ function convertHostToSSHProfile (host: string, settings: Record<string, string 
             case SSHProfilePropertyNames.ReadyTimeout:
                 const secondsString = settings[key]
                 if (typeof secondsString === 'string') {
-                    options[targetName] = parseInt(secondsString, 10) * 1000
+                    const parsedSeconds = parseInt(secondsString, 10)
+                    if (!isNaN(parsedSeconds) && parsedSeconds >= 0) {
+                        options[targetName] = parsedSeconds * 1000
+                    } else {
+                        console.log(`Invalid value for ${key}: "${secondsString}"`)
+                    }
                 } else {
                     console.log('Unexpected value in settings for ' + key)
                 }


### PR DESCRIPTION
OpenSSH's ServerAliveInterval and ConnectTimeout are in seconds, while Tabby handles them as milliseconds.
To fix this incompatibility, the import process now multiplies these values by 1000, converting them from seconds to ms.