### PR TITLE
fix(ssh): fix windows openssh agent detection logic

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -248,7 +248,17 @@ export class SSHSession {
     private async getAgentConnectionSpec (): Promise<russh.AgentConnectionSpec|null> {
         if (this.hostApp.platform === Platform.Windows) {
             if (this.config.store.ssh.agentType === 'auto') {
-                if (await fs.exists(WINDOWS_OPENSSH_AGENT_PIPE)) {
+                let pipeExists = false
+                try {
+                    await fs.stat(WINDOWS_OPENSSH_AGENT_PIPE)
+                    pipeExists = true
+                } catch (e) {
+                    if (e.code === 'EBUSY') {
+                        pipeExists = true
+                    }
+                }
+
+                if (pipeExists) {
                     return {
                         kind: 'named-pipe',
                         path: WINDOWS_OPENSSH_AGENT_PIPE,


### PR DESCRIPTION
## Summary

Fixes a bug where the OpenSSH Agent on Windows was not being detected automatically.

## Problem

On Windows, when SSH agent type is set to "Automatic", Tabby attempts to detect the OpenSSH agent by checking if the named pipe `\\.\pipe\openssh-ssh-agent` exists using `fs.exists()`.

However, when the OpenSSH agent is actively running and the pipe is in use, calling `fs.stat()` throws an `EBUSY` error instead of returning file info. The previous implementation caught this error generically and treated it as "pipe does not exist", causing agent auto-detection to incorrectly fall back to Pageant or report no agent found.

## Solution

Replace the `fs.exists()` check with explicit `fs.stat()` error handling:

- If `fs.stat()` throws `EBUSY` → pipe exists (OpenSSH agent is running)
- If `fs.stat()` throws `ENOENT` or any other error → pipe does do not exist
- If `fs.stat()` succeeds in future → pipe also exists

