### PR TITLE
Fix hiding the app from macos dock when docking is enabled

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -254,8 +254,12 @@ export class Window {
         if (process.platform === 'darwin') {
             // Lose focus
             Menu.sendActionToFirstResponder('hide:')
+            // Don't disable docked window styles when hiding - keep dock hidden if feature is enabled
             if (this.isDockedOnTop()) {
-                await this.enableDockedWindowStyles(false)
+                // Temporarily disable always-on-top and other properties while hidden
+                if (this.window.isAlwaysOnTop()) {
+                    this.window.setAlwaysOnTop(false)
+                }
             }
         }
         this.window.blur()

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -123,8 +123,8 @@ h3.mb-3(translate) Window
 
 .form-line(*ngIf='hostApp.platform !== Platform.Web && hostApp.platform !== Platform.Linux')
     .header
-        .title(translate) Hide tray
-        .description(translate) Hide Tabby in tray or menu bar.
+        .title(translate) Hide tray icon
+        .description(translate) Hide Tabby from tray or menu bar.
     toggle(
         [(ngModel)]='config.store.hideTray',
         (ngModelChange)='saveConfiguration(true)'


### PR DESCRIPTION
Resolves #9037 which is actually a bug. In MacOS it looks like the intent was to hide the application from the MacOS dock when the application is "docked" with the global hotkey, however this didn't work correctly.

Also small improvement to the description of the hideTray config setting to make it clearer that it hides the tray icon.