### PR TITLE
fix(ssh): add EOF handling and error propagation for port forwarding

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -496,48 +496,7 @@ export class SSHSession {
                 channel.close()
             })
 
-            // Channel → Socket data flow with error handling
-            channel.data$.subscribe({
-                next: data => socket.write(data),
-                error: err => {
-                    this.logger.error(`Remote forward channel error: ${err}`)
-                    socket.destroy()
-                },
-            })
-
-            // Socket → Channel data flow with proper conversion
-            socket.on('data', data => {
-                try {
-                    channel.write(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-                } catch (err) {
-                    this.logger.error(`Remote forward write error: ${err}`)
-                    socket.destroy()
-                }
-            })
-
-            // Handle EOF from remote
-            channel.eof$.subscribe(() => {
-                this.logger.debug('Remote forward channel EOF')
-                socket.end()
-            })
-
-            // Handle channel close
-            channel.closed$.subscribe(() => {
-                this.logger.debug('Remote forward channel closed')
-                socket.destroy()
-            })
-
-            // Handle socket close
-            socket.on('close', () => {
-                this.logger.debug('Remote forward socket closed')
-                channel.close()
-            })
-
-            // Handle EOF from local
-            socket.on('end', () => {
-                this.logger.debug('Remote forward socket end')
-                channel.eof()
-            })
+            this.setupSocketChannelEvents(channel, socket, 'Remote forward')
 
             socket.on('connect', () => {
                 this.logger.info('Connection forwarded')
@@ -559,19 +518,7 @@ export class SSHSession {
             try {
                 const x11Stream = await socket.connect(displaySpec)
                 this.logger.info('Connection forwarded')
-
-                channel.data$.subscribe(data => {
-                    x11Stream.write(data)
-                })
-                x11Stream.on('data', data => {
-                    channel.write(Uint8Array.from(data))
-                })
-                channel.closed$.subscribe(() => {
-                    socket.destroy()
-                })
-                x11Stream.on('close', () => {
-                    channel.close()
-                })
+                this.setupSocketChannelEvents(channel, x11Stream, 'X11 forward')
             } catch (e) {
                 // eslint-disable-next-line @typescript-eslint/no-base-to-string
                 this.emitServiceMessage(colors.bgRed.black(' X ') + ` Could not connect to the X server: ${e}`)
@@ -829,56 +776,7 @@ export class SSHSession {
                 }))
                 const socket = accept()
 
-                // Channel → Socket data flow with error handling
-                channel.data$.subscribe({
-                    next: data => {
-                        socket.write(data)
-                    },
-                    error: err => {
-                        this.logger.error(`Channel data error: ${err}`)
-                        socket.destroy(new Error(`SSH channel error: ${err}`))
-                    },
-                })
-
-                // Socket → Channel data flow with proper conversion
-                socket.on('data', data => {
-                    try {
-                        channel.write(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-                    } catch (err) {
-                        this.logger.error(`Channel write failed: ${err}`)
-                        socket.destroy(new Error(`Failed to write to SSH channel: ${err}`))
-                    }
-                })
-
-                // Handle EOF from remote (critical for bi-directional communication)
-                channel.eof$.subscribe(() => {
-                    this.logger.debug('Channel EOF received, ending socket')
-                    socket.end() // Half-close socket
-                })
-
-                // Handle full channel close
-                channel.closed$.subscribe(() => {
-                    this.logger.debug('Channel closed, destroying socket')
-                    socket.destroy()
-                })
-
-                // Handle socket errors
-                socket.on('error', err => {
-                    this.logger.error(`Socket error: ${err}`)
-                    channel.close()
-                })
-
-                // Handle socket close
-                socket.on('close', () => {
-                    this.logger.debug('Socket closed, closing channel')
-                    channel.close()
-                })
-
-                // Handle EOF from local (send EOF to remote)
-                socket.on('end', () => {
-                    this.logger.debug('Socket end, sending EOF to channel')
-                    channel.eof() // Send EOF to remote
-                })
+                this.setupSocketChannelEvents(channel, socket, 'Local forward')
             }).then(() => {
                 this.emitServiceMessage(colors.bgGreen.black(' -> ') + ` Forwarded ${fw}`)
                 this.forwardedPorts.push(fw)
@@ -950,6 +848,57 @@ export class SSHSession {
         }
         await ch.requestShell()
         return ch
+    }
+
+    private setupSocketChannelEvents (channel: russh.Channel, socket: Socket, logPrefix: string): void {
+        // Channel → Socket data flow with error handling
+        channel.data$.subscribe({
+            next: data => socket.write(data),
+            error: err => {
+                this.logger.error(`${logPrefix}: channel data error: ${err}`)
+                socket.destroy()
+            },
+        })
+
+        // Socket → Channel data flow with proper conversion
+        socket.on('data', data => {
+            try {
+                channel.write(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
+            } catch (err) {
+                this.logger.error(`${logPrefix}: channel write error: ${err}`)
+                socket.destroy(new Error(`${logPrefix}failed to write to channel: ${err}`))
+            }
+        })
+
+        // Handle EOF from remote
+        channel.eof$.subscribe(() => {
+            this.logger.debug(`${logPrefix}: channel EOF received, ending socket`)
+            socket.end()
+        })
+
+        // Handle channel close
+        channel.closed$.subscribe(() => {
+            this.logger.debug(`${logPrefix}: channel closed, destroying socket`)
+            socket.destroy()
+        })
+
+        // Handle socket errors
+        socket.on('error', err => {
+            this.logger.error(`${logPrefix}: socket error: ${err}`)
+            channel.close()
+        })
+
+        // Handle socket close
+        socket.on('close', () => {
+            this.logger.debug(`${logPrefix}: socket closed, closing channel`)
+            channel.close()
+        })
+
+        // Handle EOF from local
+        socket.on('end', () => {
+            this.logger.debug(`${logPrefix}: socket end, sending EOF to channel`)
+            channel.eof()
+        })
     }
 
     async loadPrivateKey (name: string, privateKeyContents: Buffer): Promise<russh.KeyPair> {


### PR DESCRIPTION
Fixes port forwarding issues introduced in russh migration where bi-directional communication would hang

The russh migration (v1.0.216) replaced Node.js Streams with RxJS Observables, requiring explicit EOF (End-Of-File) and error handling. The previous implementation only handled full connection closure but not half-closure (EOF) scenarios, causing applications requiring bi-directional communication to deadlock.

  **Root Cause:**
  In ssh2, EOF was automatically propagated via Stream 'end' events. With russh's Observable-based API, EOF must be explicitly handled via channel.eof$ subscriptions. Without this, when a remote server sent EOF to signal "done sending, waiting for response", the local socket never received notification, causing both sides to wait indefinitely.

  **Changes Made:**

  1. **EOF Propagation (Remote → Local)**
     - Added channel.eof$.subscribe() handlers in both local and remote forwarding
     - Calls socket.end() on EOF to properly half-close the connection
     - Critical for HTTP POST/PUT operations with "100 Continue" responses

  2. **EOF Signaling (Local → Remote)**
     - Added socket.on('end') handlers to call channel.eof()
     - Enables proper half-duplex communication

  3. **Error Handling**
     - Added error callbacks to Observable subscriptions
     - Prevents silent failures and orphaned connections
     - Added comprehensive logging for debugging

  4. **Buffer Conversion Fix**
     - Changed Uint8Array.from(data) to new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
     - The old method created incorrect array structure [98, 117, 102...] instead of proper typed array
     - Provides zero-copy view of buffer data for better performance

  5. **Additional Event Handlers**
     - Added socket.on('error') handlers to properly close channels on socket errors
     - Added debug logging for connection lifecycle events

  **Affected Code:**
  - Lines ~830-880: Local/Dynamic port forwarding (ssh -L and -D)
  - Lines ~500-550: Remote port forwarding (ssh -R)

  **Issues Fixed:**
  - MySQL/MariaDB connections through tunnels (timeout reading packets)
  - Web applications with bi-directional communication
  - Port forwarding freezes after server restart
  - General port forwarding reliability issues

  Fixes #10340
  Fixes #10142
  Fixes #10116
  Related to #10711, #10331