### PR TITLE
feat: Add Touch ID support for unlocking the Vault on macOS

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4393,8 +4393,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4411,6 +4410,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -4494,8 +4502,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4522,6 +4529,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.2"
@@ -5035,8 +5049,7 @@ worker-farm@^1.6.0, worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5053,6 +5066,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -2410,8 +2410,60 @@ msgstr ""
 msgid "Vault is locked"
 msgstr ""
 
+#: locale/tmp-html/tabby-core/src/components/unlockVaultModal.component.html:23
+msgid "Touch ID has expired. Please enter your passphrase."
+msgstr ""
+
+#: locale/tmp-html/tabby-core/src/components/unlockVaultModal.component.html:33
+msgid "Unlock with Touch ID"
+msgstr ""
+
+#: locale/tmp-html/tabby-core/src/components/unlockVaultModal.component.html:40
+msgid "or enter passphrase"
+msgstr ""
+
+#: tabby-core/src/components/unlockVaultModal.component.ts:53
+msgid "Unlock Tabby Vault"
+msgstr ""
+
+#: tabby-core/src/components/unlockVaultModal.component.ts:62
+msgid "Could not retrieve passphrase"
+msgstr ""
+
+#: tabby-core/src/components/unlockVaultModal.component.ts:66
+msgid "Touch ID failed"
+msgstr ""
+
 #: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:3
 msgid "Vault is not configured"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:49
+msgid "Use Touch ID to unlock"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:50
+msgid "Unlock the vault using Touch ID instead of entering the passphrase"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:55
+msgid "Touch ID expires after"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:56
+msgid "After this period, you will need to enter the passphrase again"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:66
+msgid "Expire on restart"
+msgstr ""
+
+#: locale/tmp-html/tabby-settings/src/components/vaultSettingsTab.component.html:67
+msgid "Require passphrase after computer restart"
+msgstr ""
+
+#: tabby-settings/src/components/vaultSettingsTab.component.ts:68
+msgid "Enable Touch ID for Vault"
 msgstr ""
 
 #: tabby-core/src/services/fileProviders.service.ts:40

--- a/tabby-core/src/api/platform.ts
+++ b/tabby-core/src/api/platform.ts
@@ -280,7 +280,7 @@ export abstract class PlatformService {
     }
 
     // Secure storage for vault passphrase (uses macOS Keychain via safeStorage)
-    isSecureStorageAvailable (): boolean {
+    async isSecureStorageAvailable (): Promise<boolean> {
         return false
     }
 

--- a/tabby-core/src/api/platform.ts
+++ b/tabby-core/src/api/platform.ts
@@ -269,6 +269,50 @@ export abstract class PlatformService {
     abstract showMessageBox (options: MessageBoxOptions): Promise<MessageBoxResult>
     abstract pickDirectory (): Promise<string | null>
     abstract quit (): void
+
+    // Biometric authentication (Touch ID on macOS)
+    async isBiometricAuthAvailable (): Promise<boolean> {
+        return false
+    }
+
+    async promptBiometricAuth (_reason: string): Promise<void> {
+        throw new Error('Biometric authentication not available')
+    }
+
+    // Secure storage for vault passphrase (uses macOS Keychain via safeStorage)
+    isSecureStorageAvailable (): boolean {
+        return false
+    }
+
+    async secureStorePassphrase (_passphrase: string): Promise<void> {
+        throw new Error('Secure storage not available')
+    }
+
+    async secureRetrievePassphrase (): Promise<string|null> {
+        return null
+    }
+
+    async secureDeletePassphrase (): Promise<void> {
+        // No-op by default
+    }
+
+    getSecureStorageTimestamp (): number|null {
+        return null
+    }
+
+    // Touch ID settings (stored separately from encrypted config)
+    getTouchIdSettings (): { enabled: boolean, expireDays: number, expireOnRestart: boolean } {
+        return { enabled: false, expireDays: 1, expireOnRestart: false }
+    }
+
+    async setTouchIdSettings (_enabled: boolean, _expireDays: number, _expireOnRestart?: boolean): Promise<void> {
+        // No-op by default
+    }
+
+    // Check if Touch ID should be considered expired (including restart check)
+    isTouchIdExpired (): boolean {
+        return true
+    }
 }
 
 export class HTMLFileUpload extends FileUpload {

--- a/tabby-core/src/components/unlockVaultModal.component.pug
+++ b/tabby-core/src/components/unlockVaultModal.component.pug
@@ -19,6 +19,28 @@
                     (click)='rememberFor = x',
                 ) {{getRememberForDisplay(x)}}
 
+    // Touch ID expired warning
+    .alert.alert-warning.mb-3(*ngIf='touchIdExpired')
+        i.fas.fa-clock.me-2
+        span(translate) Touch ID has expired. Please enter your passphrase.
+
+    // Touch ID error message
+    .alert.alert-danger.mb-3(*ngIf='touchIdError')
+        i.fas.fa-exclamation-triangle.me-2
+        span {{touchIdError}}
+
+    // Touch ID button (show when available, enabled, and not expired)
+    .d-flex.justify-content-center.mb-3(*ngIf='touchIdAvailable && touchIdEnabled && !touchIdExpired')
+        button.btn.btn-lg.btn-outline-primary((click)='unlockWithTouchId()')
+            i.fas.fa-fingerprint.me-2
+            span(translate) Unlock with Touch ID
+
+    // Divider when Touch ID is available
+    .d-flex.align-items-center.mb-3(*ngIf='touchIdAvailable && touchIdEnabled && !touchIdExpired')
+        hr.flex-grow-1.me-2
+        span.text-muted(translate) or enter passphrase
+        hr.flex-grow-1.ms-2
+
     .input-group
         input.form-control.form-control-lg(
             type='password',

--- a/tabby-core/src/components/unlockVaultModal.component.pug
+++ b/tabby-core/src/components/unlockVaultModal.component.pug
@@ -44,7 +44,6 @@
     .input-group
         input.form-control.form-control-lg(
             type='password',
-            autofocus,
             [(ngModel)]='passphrase',
             #input,
             placeholder='Master passphrase',

--- a/tabby-core/src/components/unlockVaultModal.component.pug
+++ b/tabby-core/src/components/unlockVaultModal.component.pug
@@ -31,7 +31,7 @@
 
     // Touch ID button (show when available, enabled, and not expired)
     .d-flex.justify-content-center.mb-3(*ngIf='touchIdAvailable && touchIdEnabled && !touchIdExpired')
-        button.btn.btn-lg.btn-outline-primary((click)='unlockWithTouchId()')
+        button.btn.btn-lg.btn-primary((click)='unlockWithTouchId()')
             i.fas.fa-fingerprint.me-2
             span(translate) Unlock with Touch ID
 

--- a/tabby-core/src/components/unlockVaultModal.component.ts
+++ b/tabby-core/src/components/unlockVaultModal.component.ts
@@ -28,7 +28,10 @@ export class UnlockVaultModalComponent {
         this.rememberFor = parseInt(window.localStorage.vaultRememberPassphraseFor ?? 0)
 
         // Check Touch ID availability and status
-        this.touchIdAvailable = await this.platform.isBiometricAuthAvailable()
+        const biometricAvailable = await (this.platform.isBiometricAuthAvailable() as any)
+        const secureStorageAvailable = await (this.platform.isSecureStorageAvailable() as any)
+        this.touchIdAvailable = biometricAvailable && secureStorageAvailable
+
         const touchIdSettings = this.platform.getTouchIdSettings()
         this.touchIdEnabled = touchIdSettings.enabled
 

--- a/tabby-core/src/components/unlockVaultModal.component.ts
+++ b/tabby-core/src/components/unlockVaultModal.component.ts
@@ -60,6 +60,8 @@ export class UnlockVaultModalComponent {
                 })
             } else {
                 this.touchIdError = this.translate.instant('Could not retrieve passphrase')
+                // Hide Touch ID button since the stored passphrase seems invalid
+                this.touchIdEnabled = false
             }
         } catch (e: any) {
             // User cancelled or Touch ID failed

--- a/tabby-core/src/components/unlockVaultModal.component.ts
+++ b/tabby-core/src/components/unlockVaultModal.component.ts
@@ -1,5 +1,7 @@
 import { Component, ViewChild, ElementRef } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import { PlatformService } from '../api/platform'
+import { TranslateService } from '@ngx-translate/core'
 
 /** @hidden */
 @Component({
@@ -11,15 +13,58 @@ export class UnlockVaultModalComponent {
     rememberOptions = [1, 5, 15, 60, 1440, 10080]
     @ViewChild('input') input: ElementRef
 
+    touchIdAvailable = false
+    touchIdEnabled = false
+    touchIdExpired = false
+    touchIdError = ''
+
     constructor (
         private modalInstance: NgbActiveModal,
+        private platform: PlatformService,
+        private translate: TranslateService,
     ) { }
 
-    ngOnInit (): void {
+    async ngOnInit (): Promise<void> {
         this.rememberFor = parseInt(window.localStorage.vaultRememberPassphraseFor ?? 0)
+
+        // Check Touch ID availability and status
+        this.touchIdAvailable = await this.platform.isBiometricAuthAvailable()
+        const touchIdSettings = this.platform.getTouchIdSettings()
+        this.touchIdEnabled = touchIdSettings.enabled
+
+        if (this.touchIdAvailable && this.touchIdEnabled) {
+            // Check if Touch ID has expired (time-based or restart-based)
+            this.touchIdExpired = this.platform.isTouchIdExpired()
+
+            // Auto-trigger Touch ID if available and not expired
+            if (!this.touchIdExpired) {
+                await this.unlockWithTouchId()
+            }
+        }
+
         setTimeout(() => {
-            this.input.nativeElement.focus()
+            this.input.nativeElement?.focus()
         })
+    }
+
+    async unlockWithTouchId (): Promise<void> {
+        this.touchIdError = ''
+        try {
+            await this.platform.promptBiometricAuth(this.translate.instant('Unlock Tabby Vault'))
+            const passphrase = await this.platform.secureRetrievePassphrase()
+            if (passphrase) {
+                this.modalInstance.close({
+                    passphrase,
+                    rememberFor: this.rememberFor,
+                    usedTouchId: true,
+                })
+            } else {
+                this.touchIdError = this.translate.instant('Could not retrieve passphrase')
+            }
+        } catch (e: any) {
+            // User cancelled or Touch ID failed
+            this.touchIdError = e.message || this.translate.instant('Touch ID failed')
+        }
     }
 
     ok (): void {
@@ -27,6 +72,9 @@ export class UnlockVaultModalComponent {
         this.modalInstance.close({
             passphrase: this.passphrase,
             rememberFor: this.rememberFor,
+            usedTouchId: false,
+            // Update Touch ID storage when enabled (both when expired and to refresh timestamp)
+            updateTouchId: this.touchIdEnabled,
         })
     }
 

--- a/tabby-electron/src/services/electron.service.ts
+++ b/tabby-electron/src/services/electron.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { App, IpcRenderer, Shell, Dialog, Clipboard, GlobalShortcut, Screen, AutoUpdater, TouchBar, BrowserWindow, Menu, MenuItem, PowerSaveBlocker, NativeTheme } from 'electron'
+import { App, IpcRenderer, Shell, Dialog, Clipboard, GlobalShortcut, Screen, AutoUpdater, TouchBar, BrowserWindow, Menu, MenuItem, PowerSaveBlocker, NativeTheme, SystemPreferences } from 'electron'
 import * as remote from '@electron/remote'
 
 export interface MessageBoxResponse {
@@ -24,6 +24,7 @@ export class ElectronService {
     BrowserWindow: typeof BrowserWindow
     Menu: typeof Menu
     MenuItem: typeof MenuItem
+    systemPreferences: SystemPreferences
 
     /** @hidden */
     private constructor () {
@@ -44,5 +45,6 @@ export class ElectronService {
         this.Menu = remote.Menu
         this.MenuItem = remote.MenuItem
         this.nativeTheme = remote.nativeTheme
+        this.systemPreferences = remote.systemPreferences
     }
 }

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -411,14 +411,15 @@ export class ElectronPlatformService extends PlatformService {
     }
 
     async secureDeletePassphrase (): Promise<void> {
-        this.touchIdCache = null
-        try {
-            if (fsSync.existsSync(this.touchIdStoragePath)) {
-                await fs.unlink(this.touchIdStoragePath)
-            }
-        } catch {
-            // Ignore errors
+        this.loadTouchIdCache()
+        if (!this.touchIdCache) {
+            return
         }
+
+        this.touchIdCache.encrypted = []
+        this.touchIdCache.timestamp = 0
+        this.touchIdCache.bootTime = undefined
+        await this.saveTouchIdCache()
     }
 
     getSecureStorageTimestamp (): number|null {

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -358,6 +358,11 @@ export class ElectronPlatformService extends PlatformService {
     private async saveTouchIdCache (): Promise<void> {
         if (this.touchIdCache) {
             await fs.writeFile(this.touchIdStoragePath, JSON.stringify(this.touchIdCache), 'utf8')
+            try {
+                await fs.chmod(this.touchIdStoragePath, 0o600)
+            } catch {
+                // Ignore permission-setting errors to avoid breaking functionality on unsupported platforms
+            }
         }
     }
 

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -379,9 +379,12 @@ export class ElectronPlatformService extends PlatformService {
         return this.electron.systemPreferences.promptTouchID(reason)
     }
 
-    isSecureStorageAvailable (): boolean {
+    async isSecureStorageAvailable (): Promise<boolean> {
         // safeStorage is available via main process IPC
-        return this.hostApp.platform === Platform.macOS
+        if (this.hostApp.platform !== Platform.macOS) {
+            return false
+        }
+        return this.electron.ipcRenderer.invoke('app:safe-storage-available')
     }
 
     async secureStorePassphrase (passphrase: string): Promise<void> {

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -339,7 +339,7 @@ export class ElectronPlatformService extends PlatformService {
 
     private getBootTime (): number {
         // Calculate boot time from current time minus uptime
-        return Date.now() - (os.uptime() * 1000)
+        return Date.now() - os.uptime() * 1000
     }
 
     private loadTouchIdCache (): void {
@@ -399,7 +399,7 @@ export class ElectronPlatformService extends PlatformService {
     async secureRetrievePassphrase (): Promise<string|null> {
         try {
             this.loadTouchIdCache()
-            if (!this.touchIdCache || !this.touchIdCache.encrypted?.length) {
+            if (!this.touchIdCache?.encrypted.length) {
                 return null
             }
             const encrypted = Buffer.from(this.touchIdCache.encrypted)

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -322,6 +322,158 @@ export class ElectronPlatformService extends PlatformService {
             return 'light'
         }
     }
+
+    // Touch ID / Biometric methods (macOS only)
+    private touchIdCache: {
+        encrypted: number[],
+        timestamp: number,
+        enabled?: boolean,
+        expireDays?: number,
+        expireOnRestart?: boolean,
+        bootTime?: number,
+    }|null = null
+
+    private get touchIdStoragePath (): string {
+        return path.join(path.dirname(this.configPath), 'vault-touchid.json')
+    }
+
+    private getBootTime (): number {
+        // Calculate boot time from current time minus uptime
+        return Date.now() - (os.uptime() * 1000)
+    }
+
+    private loadTouchIdCache (): void {
+        if (!this.touchIdCache) {
+            if (fsSync.existsSync(this.touchIdStoragePath)) {
+                try {
+                    const content = fsSync.readFileSync(this.touchIdStoragePath, 'utf8')
+                    this.touchIdCache = JSON.parse(content)
+                } catch {
+                    this.touchIdCache = null
+                }
+            }
+        }
+    }
+
+    private async saveTouchIdCache (): Promise<void> {
+        if (this.touchIdCache) {
+            await fs.writeFile(this.touchIdStoragePath, JSON.stringify(this.touchIdCache), 'utf8')
+        }
+    }
+
+    async isBiometricAuthAvailable (): Promise<boolean> {
+        if (this.hostApp.platform !== Platform.macOS) {
+            return false
+        }
+        try {
+            return this.electron.systemPreferences.canPromptTouchID()
+        } catch {
+            return false
+        }
+    }
+
+    async promptBiometricAuth (reason: string): Promise<void> {
+        if (this.hostApp.platform !== Platform.macOS) {
+            throw new Error('Biometric authentication is only available on macOS')
+        }
+        return this.electron.systemPreferences.promptTouchID(reason)
+    }
+
+    isSecureStorageAvailable (): boolean {
+        // safeStorage is available via main process IPC
+        return this.hostApp.platform === Platform.macOS
+    }
+
+    async secureStorePassphrase (passphrase: string): Promise<void> {
+        const encrypted: Buffer = await this.electron.ipcRenderer.invoke('app:safe-storage-encrypt', passphrase)
+        this.loadTouchIdCache()
+        if (!this.touchIdCache) {
+            this.touchIdCache = { encrypted: [], timestamp: 0 }
+        }
+        this.touchIdCache.encrypted = Array.from(encrypted)
+        this.touchIdCache.timestamp = Date.now()
+        this.touchIdCache.bootTime = this.getBootTime()
+        await this.saveTouchIdCache()
+    }
+
+    async secureRetrievePassphrase (): Promise<string|null> {
+        try {
+            this.loadTouchIdCache()
+            if (!this.touchIdCache || !this.touchIdCache.encrypted?.length) {
+                return null
+            }
+            const encrypted = Buffer.from(this.touchIdCache.encrypted)
+            const decrypted: string = await this.electron.ipcRenderer.invoke('app:safe-storage-decrypt', encrypted)
+            return decrypted
+        } catch {
+            return null
+        }
+    }
+
+    async secureDeletePassphrase (): Promise<void> {
+        this.touchIdCache = null
+        try {
+            if (fsSync.existsSync(this.touchIdStoragePath)) {
+                await fs.unlink(this.touchIdStoragePath)
+            }
+        } catch {
+            // Ignore errors
+        }
+    }
+
+    getSecureStorageTimestamp (): number|null {
+        this.loadTouchIdCache()
+        return this.touchIdCache?.timestamp ?? null
+    }
+
+    getTouchIdSettings (): { enabled: boolean, expireDays: number, expireOnRestart: boolean } {
+        this.loadTouchIdCache()
+        return {
+            enabled: this.touchIdCache?.enabled ?? false,
+            expireDays: this.touchIdCache?.expireDays ?? 1,
+            expireOnRestart: this.touchIdCache?.expireOnRestart ?? false,
+        }
+    }
+
+    async setTouchIdSettings (enabled: boolean, expireDays: number, expireOnRestart?: boolean): Promise<void> {
+        this.loadTouchIdCache()
+        if (!this.touchIdCache) {
+            this.touchIdCache = { encrypted: [], timestamp: 0 }
+        }
+        this.touchIdCache.enabled = enabled
+        this.touchIdCache.expireDays = expireDays
+        this.touchIdCache.expireOnRestart = expireOnRestart ?? false
+        await this.saveTouchIdCache()
+    }
+
+    isTouchIdExpired (): boolean {
+        this.loadTouchIdCache()
+        if (!this.touchIdCache?.enabled) {
+            return true
+        }
+
+        // Check restart-based expiration
+        if (this.touchIdCache.expireOnRestart) {
+            const storedBootTime = this.touchIdCache.bootTime
+            const currentBootTime = this.getBootTime()
+            // Allow 5 second tolerance for boot time comparison
+            if (!storedBootTime || Math.abs(currentBootTime - storedBootTime) > 5000) {
+                return true
+            }
+        }
+
+        // Check time-based expiration
+        const timestamp = this.touchIdCache.timestamp
+        const expireDays = this.touchIdCache.expireDays ?? 1
+        if (expireDays > 0 && timestamp) {
+            const expireMs = expireDays * 24 * 60 * 60 * 1000
+            if (Date.now() - timestamp > expireMs) {
+                return true
+            }
+        }
+
+        return false
+    }
 }
 
 class ElectronFileUpload extends FileUpload {

--- a/tabby-settings/src/components/vaultSettingsTab.component.pug
+++ b/tabby-settings/src/components/vaultSettingsTab.component.pug
@@ -61,6 +61,56 @@ div(*ngIf='vault.isEnabled()')
                             span(translate) Delete
 
         h3.mt-5(translate) Options
+
+        // Touch ID option (macOS only)
+        .form-line(*ngIf='touchIdAvailable')
+            .header
+                .title
+                    i.fas.fa-fingerprint.me-2
+                    span(translate) Use Touch ID to unlock
+                .description(translate) Unlock the vault using Touch ID instead of entering the passphrase
+            toggle(
+                [ngModel]='touchIdEnabled',
+                (ngModelChange)='toggleTouchId()',
+            )
+
+        // Touch ID expire days (show only when Touch ID is enabled)
+        .form-line(*ngIf='touchIdAvailable && touchIdEnabled')
+            .header
+                .title(translate) Touch ID expires after
+                .description(translate) After this period, you will need to enter the passphrase again
+            .d-flex.align-items-center.gap-2
+                select.form-control(
+                    style='width: auto',
+                    [ngModel]='touchIdExpireDays',
+                    (ngModelChange)='setTouchIdExpireDays($event)',
+                )
+                    option(
+                        *ngFor='let opt of touchIdExpireOptions',
+                        [ngValue]='opt.value',
+                    ) {{opt.label | translate}}
+                    option([ngValue]='-1', translate) Custom
+                // Custom days input (show when custom is selected)
+                .input-group(*ngIf='touchIdExpireDays === -1 || (touchIdExpireDays > 0 && touchIdExpireDays !== 1 && touchIdExpireDays !== 7 && touchIdExpireDays !== 30)', style='width: 120px')
+                    input.form-control(
+                        type='number',
+                        min='1',
+                        max='30',
+                        [ngModel]='customExpireDays',
+                        (ngModelChange)='setCustomExpireDays($event)',
+                    )
+                    span.input-group-text(translate) days
+
+        // Expire on restart (show only when Touch ID is enabled)
+        .form-line(*ngIf='touchIdAvailable && touchIdEnabled')
+            .header
+                .title(translate) Expire on restart
+                .description(translate) Require passphrase after computer restart
+            toggle(
+                [ngModel]='touchIdExpireOnRestart',
+                (ngModelChange)='setTouchIdExpireOnRestart($event)',
+            )
+
         .form-line
             .header
                 .title(translate) Encrypt config file

--- a/tabby-settings/src/components/vaultSettingsTab.component.pug
+++ b/tabby-settings/src/components/vaultSettingsTab.component.pug
@@ -82,7 +82,7 @@ div(*ngIf='vault.isEnabled()')
             .d-flex.align-items-center.gap-2
                 select.form-control(
                     style='width: auto',
-                    [ngModel]='touchIdExpireDays',
+                    [ngModel]='touchIdExpireSelection',
                     (ngModelChange)='setTouchIdExpireDays($event)',
                 )
                     option(
@@ -91,7 +91,7 @@ div(*ngIf='vault.isEnabled()')
                     ) {{opt.label | translate}}
                     option([ngValue]='-1', translate) Custom
                 // Custom days input (show when custom is selected)
-                .input-group(*ngIf='touchIdExpireDays === -1 || (touchIdExpireDays > 0 && touchIdExpireDays !== 1 && touchIdExpireDays !== 7 && touchIdExpireDays !== 30)', style='width: 120px')
+                .input-group(*ngIf='touchIdExpireSelection === -1', style='width: 120px')
                     input.form-control(
                         type='number',
                         min='1',

--- a/tabby-settings/src/components/vaultSettingsTab.component.pug
+++ b/tabby-settings/src/components/vaultSettingsTab.component.pug
@@ -96,6 +96,7 @@ div(*ngIf='vault.isEnabled()')
                         type='number',
                         min='1',
                         max='30',
+                        step='1',
                         [ngModel]='customExpireDays',
                         (ngModelChange)='setCustomExpireDays($event)',
                     )

--- a/tabby-settings/src/components/vaultSettingsTab.component.pug
+++ b/tabby-settings/src/components/vaultSettingsTab.component.pug
@@ -71,7 +71,7 @@ div(*ngIf='vault.isEnabled()')
                 .description(translate) Unlock the vault using Touch ID instead of entering the passphrase
             toggle(
                 [ngModel]='touchIdEnabled',
-                (ngModelChange)='toggleTouchId()',
+                (ngModelChange)='toggleTouchId($event)',
             )
 
         // Touch ID expire days (show only when Touch ID is enabled)

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -24,6 +24,8 @@ export class VaultSettingsTabComponent extends BaseComponent {
         { value: 0, label: 'Never expire' },
     ]
 
+    private touchIdExpirePresetValues = [1, 7, 30, 0]
+
     customExpireDays = 1
 
     @HostBinding('class.content-box') true
@@ -46,6 +48,11 @@ export class VaultSettingsTabComponent extends BaseComponent {
         const biometricAvailable = await this.platform.isBiometricAuthAvailable()
         const secureStorageAvailable = this.platform.isSecureStorageAvailable()
         this.touchIdAvailable = biometricAvailable && secureStorageAvailable
+
+        const expireDays = this.platform.getTouchIdSettings().expireDays
+        if (expireDays > 0 && !this.touchIdExpirePresetValues.includes(expireDays)) {
+            this.customExpireDays = expireDays
+        }
     }
 
     get touchIdEnabled (): boolean {
@@ -54,6 +61,14 @@ export class VaultSettingsTabComponent extends BaseComponent {
 
     get touchIdExpireDays (): number {
         return this.platform.getTouchIdSettings().expireDays
+    }
+
+    get touchIdExpireSelection (): number {
+        const expireDays = this.touchIdExpireDays
+        if (expireDays > 0 && !this.touchIdExpirePresetValues.includes(expireDays)) {
+            return -1
+        }
+        return expireDays
     }
 
     get touchIdExpireOnRestart (): boolean {
@@ -92,6 +107,10 @@ export class VaultSettingsTabComponent extends BaseComponent {
     }
 
     async setTouchIdExpireDays (days: number): Promise<void> {
+        if (days === -1) {
+            await this.platform.setTouchIdSettings(true, this.customExpireDays, this.touchIdExpireOnRestart)
+            return
+        }
         await this.platform.setTouchIdSettings(true, days, this.touchIdExpireOnRestart)
     }
 

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -196,7 +196,7 @@ export class VaultSettingsTabComponent extends BaseComponent {
         const modal = this.ngbModal.open(SetVaultPassphraseModalComponent)
         const newPassphrase = await modal.result.catch(() => null)
         if (newPassphrase) {
-            this.vault.save(this.vaultContents, newPassphrase)
+            await this.vault.save(this.vaultContents, newPassphrase)
             // Update Touch ID storage if enabled
             if (this.touchIdEnabled) {
                 await this.platform.secureStorePassphrase(newPassphrase)

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -43,7 +43,9 @@ export class VaultSettingsTabComponent extends BaseComponent {
     }
 
     async checkTouchIdAvailability (): Promise<void> {
-        this.touchIdAvailable = await this.platform.isBiometricAuthAvailable()
+        const biometricAvailable = await this.platform.isBiometricAuthAvailable()
+        const secureStorageAvailable = this.platform.isSecureStorageAvailable()
+        this.touchIdAvailable = biometricAvailable && secureStorageAvailable
     }
 
     get touchIdEnabled (): boolean {
@@ -76,6 +78,8 @@ export class VaultSettingsTabComponent extends BaseComponent {
     }
 
     async disableTouchId (): Promise<void> {
+        const settings = this.platform.getTouchIdSettings()
+        await this.platform.setTouchIdSettings(false, settings.expireDays, settings.expireOnRestart)
         await this.platform.secureDeletePassphrase()
     }
 

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -118,15 +118,15 @@ export class VaultSettingsTabComponent extends BaseComponent {
     async setTouchIdExpireDays (days: number): Promise<void> {
         if (days === -1) {
             this.customExpireSelected = true
-            await this.platform.setTouchIdSettings(true, this.customExpireDays, this.touchIdExpireOnRestart)
+            await this.platform.setTouchIdSettings(this.touchIdEnabled, this.customExpireDays, this.touchIdExpireOnRestart)
             return
         }
         this.customExpireSelected = false
-        await this.platform.setTouchIdSettings(true, days, this.touchIdExpireOnRestart)
+        await this.platform.setTouchIdSettings(this.touchIdEnabled, days, this.touchIdExpireOnRestart)
     }
 
     async setTouchIdExpireOnRestart (value: boolean): Promise<void> {
-        await this.platform.setTouchIdSettings(true, this.touchIdExpireDays, value)
+        await this.platform.setTouchIdSettings(this.touchIdEnabled, this.touchIdExpireDays, value)
     }
 
     async setCustomExpireDays (days: number): Promise<void> {
@@ -141,7 +141,7 @@ export class VaultSettingsTabComponent extends BaseComponent {
         } else {
             this.customExpireDays = validatedDays
         }
-        await this.platform.setTouchIdSettings(true, validatedDays, this.touchIdExpireOnRestart)
+        await this.platform.setTouchIdSettings(this.touchIdEnabled, validatedDays, this.touchIdExpireOnRestart)
     }
 
     async loadVault (): Promise<void> {

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -47,8 +47,8 @@ export class VaultSettingsTabComponent extends BaseComponent {
     }
 
     async checkTouchIdAvailability (): Promise<void> {
-        const biometricAvailable = await this.platform.isBiometricAuthAvailable()
-        const secureStorageAvailable = this.platform.isSecureStorageAvailable()
+        const biometricAvailable = await (this.platform.isBiometricAuthAvailable() as any)
+        const secureStorageAvailable = await (this.platform.isSecureStorageAvailable() as any)
         this.touchIdAvailable = biometricAvailable && secureStorageAvailable
 
         let expireDays = this.platform.getTouchIdSettings().expireDays

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -137,7 +137,7 @@ export class VaultSettingsTabComponent extends BaseComponent {
         await this.platform.setTouchIdSettings(this.touchIdEnabled, this.touchIdExpireDays, value)
     }
 
-    async setCustomExpireDays (days: number): Promise<void> {
+    async setCustomExpireDays (days: number|null|undefined): Promise<void> {
         if (days === null || days === undefined) {
             return
         }


### PR DESCRIPTION
Support #10963 

## Implementation
1. Use [systemPreferences.promptTouchID()](https://www.electronjs.org/docs/latest/api/system-preferences#systempreferencesprompttouchidreason-macos) on macOS for biometric auth.
2. Encrypt/decrypt the Vault passphrase via main-process `safeStorage`.
3. Auto-triggers Touch ID on the unlock modal; falls back to passphrase on failure/expiry.
<img width="777" height="351" alt="Snipaste_2026-01-18_00-46-46@2x" src="https://github.com/user-attachments/assets/fd657567-77f9-4ed6-a182-71404a793b92" />

4. Touch ID settings are stored separately from encrypted config.

## Options
1. Enable/disable Touch ID unlock
2. Expiration policy: 1/7/30 days to select or custom days between 1-30.
3. Expire after restart
<img width="867" height="568" alt="Snipaste_2026-01-18_00-47-09@2x" src="https://github.com/user-attachments/assets/46530e55-9369-48e6-b118-624446d5b408" />

## Request
I also use Windows but as far as I know Electron has no native support for Windows Hello. 
If you know a usable solution, please tell me or PR to the project, thanks.