### PR TITLE
fix(ssh): avoid undefined .filter() during SSH connection introduced …

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -352,9 +352,9 @@ export class SSHSession {
 
         const algorithms = {}
         for (const key of Object.values(SSHAlgorithmType)) {
-             if(key !== SSHAlgorithmType.COMPRESSION) { 
-            algorithms[key] = this.profile.options.algorithms![key].filter(x => supportedAlgorithms[key].includes(x))
-             }
+            if (key !== SSHAlgorithmType.COMPRESSION) {
+                algorithms[key] = this.profile.options.algorithms![key].filter(x => supportedAlgorithms[key].includes(x))
+            }
         }
 
         // eslint-disable-next-line @typescript-eslint/init-declarations


### PR DESCRIPTION
…in 1.0.224

SSHAlgorithmType.COMPRESSION was added in commit 020372c but is not filterable.
This loop missed the existing guard used elsewhere, resulting in .filter() being called on an undefined value.

potentially fixes
#10619 
#10635
#10672 
#10682
#10688 
#10730  
#10843