### PR TITLE
feat: Allow third-party plugins to add quick connection support.

### DIFF
--- a/app/lib/cli.ts
+++ b/app/lib/cli.ts
@@ -30,9 +30,8 @@ export function parseArgs (argv: string[], cwd: string): any {
         })
         .command('quickConnect <providerId> <query>', 'open a tab for specified quick connect provider', yargs => {
             return yargs.positional('providerId', {
-                describe: 'The name of a quick connect profile provider',
+                describe: 'The name of a quick connect profile provider (e.g., ssh, telnet)',
                 type: 'string',
-                choices: ['ssh', 'telnet'],
             }).positional('query', {
                 describe: 'The quick connect query string',
                 type: 'string',

--- a/tabby-core/src/cli.ts
+++ b/tabby-core/src/cli.ts
@@ -55,9 +55,12 @@ export class ProfileCLIHandler extends CLIHandler {
     }
 
     private async handleOpenQuickConnect (providerId: string, query: string) {
-        const provider = this.profiles.getProviders().find(x => x.id === providerId)
-        if(!provider || !(provider instanceof QuickConnectProfileProvider)) {
-            console.error(`Requested provider "${providerId}" not found`)
+        const quickConnectProviders = this.profiles.getProviders()
+            .filter((x): x is QuickConnectProfileProvider<any> => x instanceof QuickConnectProfileProvider)
+        const provider = quickConnectProviders.find(x => x.id === providerId)
+        if(!provider) {
+            const available = quickConnectProviders.map(x => x.id).join(', ')
+            console.error(`Requested provider "${providerId}" not found. Available providers: ${available}`)
             return
         }
         const profile = provider.quickConnect(query)


### PR DESCRIPTION
## Description
This PR improves the `quickConnect` CLI command to better support third-party plugins that implement `QuickConnectProfileProvider`

Plugins available for testing: `ws-term`
Test guidance: https://github.com/ruanimal/tabby-ws-term/blob/master/docs/ws-test-server.md

## Changes
- Removed hardcoded choices in `app/lib/cli.ts` 
- Improved error messages in `tabby-core/src/cli.ts`

