### PR TITLE
Fix frosted glass persistence

### DIFF
--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -40,7 +40,7 @@ h3.mb-3(translate) Window
 
     toggle(
         [(ngModel)]='config.store.appearance.vibrancy',
-        (ngModelChange)='saveConfiguration()'
+        (ngModelChange)='config.save()'
     )
 
 .form-line(*ngIf='config.store.appearance.vibrancy && isFluentVibrancySupported && config.store.hacks.enableFluentBackground')
@@ -51,7 +51,7 @@ h3.mb-3(translate) Window
             type='radio',
             name='vibracy',
             [(ngModel)]='config.store.appearance.vibrancyType',
-            (ngModelChange)='saveConfiguration()',
+            (ngModelChange)='config.save()',
             id='vibrancyTypeBlur',
             [value]='"blur"'
         )
@@ -63,7 +63,7 @@ h3.mb-3(translate) Window
             type='radio',
             name='vibracy',
             [(ngModel)]='config.store.appearance.vibrancyType',
-            (ngModelChange)='saveConfiguration()',
+            (ngModelChange)='config.save()',
             id='vibrancyTypeFluent',
             [value]='"fluent"'
         )

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -14,7 +14,7 @@ import { SerializeAddon } from '@xterm/addon-serialize'
 import { ImageAddon } from '@xterm/addon-image'
 import { CanvasAddon } from '@xterm/addon-canvas'
 import { BaseTerminalProfile, TerminalColorScheme } from '../api/interfaces'
-import { getTerminalBackgroundColor } from '../helpers'
+import { getXtermBackgroundColor } from '../helpers'
 import './xterm.css'
 
 const COLOR_NAMES = [
@@ -394,7 +394,7 @@ export class XTermFrontend extends Frontend {
             foreground: scheme.foreground,
             selectionBackground: scheme.selection ?? '#88888888',
             selectionForeground: scheme.selectionForeground ?? undefined,
-            background: getTerminalBackgroundColor(this.configService, this.themes, scheme) ?? '#00000000',
+            background: getXtermBackgroundColor(this.configService, this.themes, scheme),
             cursor: scheme.cursor,
             cursorAccent: scheme.cursorAccent,
             overviewRulerBorder: scheme.background,

--- a/tabby-terminal/src/helpers.ts
+++ b/tabby-terminal/src/helpers.ts
@@ -1,13 +1,21 @@
 import { TerminalColorScheme } from './api/interfaces'
 import { ConfigService, ThemesService } from 'tabby-core'
 
+function getActiveTerminalTheme (
+    themes: ThemesService,
+): { appTheme: ReturnType<ThemesService['findCurrentTheme']>, appColorScheme: TerminalColorScheme } {
+    const appTheme = themes.findCurrentTheme()
+    const appColorScheme = themes._getActiveColorScheme() as TerminalColorScheme
+
+    return { appTheme, appColorScheme }
+}
+
 export function getTerminalBackgroundColor (
     config: ConfigService,
     themes: ThemesService,
     scheme: TerminalColorScheme | null,
 ): string|null {
-    const appTheme = themes.findCurrentTheme()
-    const appColorScheme = themes._getActiveColorScheme() as TerminalColorScheme
+    const { appTheme, appColorScheme } = getActiveTerminalTheme(themes)
 
     // Use non transparent background when:
     // - legacy theme and user choses colorScheme based BG
@@ -18,4 +26,18 @@ export function getTerminalBackgroundColor (
         || appTheme.followsColorScheme && scheme?.name !== appColorScheme.name
 
     return shouldUseCSBackground && scheme ? scheme.background : null
+}
+
+export function getXtermBackgroundColor (
+    config: ConfigService,
+    themes: ThemesService,
+    scheme: TerminalColorScheme | null,
+): string {
+    const configuredBackground = getTerminalBackgroundColor(config, themes, scheme)
+    if (configuredBackground) {
+        return configuredBackground
+    }
+
+    const { appTheme, appColorScheme } = getActiveTerminalTheme(themes)
+    return appTheme.followsColorScheme ? appColorScheme.background : appTheme.terminalBackground
 }


### PR DESCRIPTION
## Summary
  The frosted glass toggle was saved through the debounced settings handler. If the app was closed quickly after toggling, the change could be lost. This makes the toggle save immediately
  instead.

  Fixes #11077.

  ## Changes
  - save `appearance.vibrancy` and `appearance.vibrancyType` directly via `config.save()`

  ## Testing
  Not run.