### PR TITLE
perf: fix UI degradation with large SSH config files. Issue #11078

### DIFF
--- a/tabby-core/src/directives/fastHtmlBind.directive.ts
+++ b/tabby-core/src/directives/fastHtmlBind.directive.ts
@@ -7,6 +7,7 @@ import { PlatformService } from '../api/platform'
 })
 export class FastHtmlBindDirective implements OnChanges {
     @Input() fastHtmlBind?: string
+    private _lastValue?: string
 
     constructor (
         private el: ElementRef,
@@ -14,6 +15,10 @@ export class FastHtmlBindDirective implements OnChanges {
     ) { }
 
     ngOnChanges (): void {
+        if (this.fastHtmlBind === this._lastValue) {
+            return
+        }
+        this._lastValue = this.fastHtmlBind
         this.el.nativeElement.innerHTML = this.fastHtmlBind ?? ''
         for (const link of this.el.nativeElement.querySelectorAll('a')) {
             link.addEventListener('click', event => {

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -5,7 +5,7 @@ import { BaseTabComponent } from '../components/baseTab.component'
 import { QuickConnectProfileProvider, PartialProfile, PartialProfileGroup, Profile, ProfileGroup, ProfileProvider } from '../api/profileProvider'
 import { SelectorOption } from '../api/selector'
 import { AppService } from './app.service'
-import { configMerge, ConfigProxy, ConfigService } from './config.service'
+import { configMerge, ConfigProxy, ConfigService, FullyDefined } from './config.service'
 import { NotificationsService } from './notifications.service'
 import { SelectorService } from './selector.service'
 import deepClone from 'clone-deep'
@@ -53,8 +53,8 @@ export class ProfilesService {
     }
 
     getDescription <P extends Profile> (profile: PartialProfile<P>): string|null {
-        profile = this.getConfigProxyForProfile(profile)
-        return this.providerForProfile(profile)?.getDescription(profile) ?? null
+        const fullProfile = this.getConfigProxyForProfile(profile)
+        return this.providerForProfile(fullProfile)?.getDescription(fullProfile) ?? null
     }
 
     /*
@@ -66,9 +66,9 @@ export class ProfilesService {
     * arg: skipUserDefaults -> do not merge global provider defaults in ConfigProxy
     * arg: skipGroupDefaults -> do not merge parent group provider defaults in ConfigProxy
     */
-    getConfigProxyForProfile <T extends Profile> (profile: PartialProfile<T>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): T {
+    getConfigProxyForProfile <T extends Profile> (profile: PartialProfile<T>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): FullyDefined<T> & ConfigProxy<FullyDefined<T>> {
         const defaults = this.getProfileDefaults(profile, options).reduce(configMerge, {})
-        return new ConfigProxy(profile, defaults) as unknown as T
+        return new ConfigProxy(profile, defaults) as any
     }
 
     /**
@@ -215,6 +215,8 @@ export class ProfilesService {
         const freeInputEquivalent = provider instanceof QuickConnectProfileProvider ? provider.intoQuickConnectString(fullProfile) ?? undefined : undefined
         return {
             ...profile,
+            icon: profile.icon ?? undefined,
+            color: profile.color ?? undefined,
             group: this.resolveProfileGroupName(profile.group ?? ''),
             freeInputEquivalent,
             description: provider?.getDescription(fullProfile),
@@ -234,7 +236,7 @@ export class ProfilesService {
                     ...this.selectorOptionForProfile(p),
                     group: this.translate.instant('Recent'),
                     icon: 'fas fa-history',
-                    color: p.color,
+                    color: p.color ?? undefined,
                     weight: i - (recentProfiles.length + 1),
                     callback: async () => {
                         if (p.id) {

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -5,7 +5,7 @@ import { BaseTabComponent } from '../components/baseTab.component'
 import { QuickConnectProfileProvider, PartialProfile, PartialProfileGroup, Profile, ProfileGroup, ProfileProvider } from '../api/profileProvider'
 import { SelectorOption } from '../api/selector'
 import { AppService } from './app.service'
-import { configMerge, ConfigProxy, ConfigService, FullyDefined } from './config.service'
+import { configMerge, ConfigProxy, ConfigService } from './config.service'
 import { NotificationsService } from './notifications.service'
 import { SelectorService } from './selector.service'
 import deepClone from 'clone-deep'
@@ -14,7 +14,7 @@ import slugify from 'slugify'
 
 @Injectable({ providedIn: 'root' })
 export class ProfilesService {
-    private profileDefaults: Profile = {
+    private profileDefaults = {
         id: '',
         type: '',
         name: '',
@@ -26,6 +26,7 @@ export class ProfilesService {
         weight: 0,
         isBuiltin: false,
         isTemplate: false,
+        terminalColorScheme: null,
         behaviorOnSessionEnd: 'auto',
     }
 
@@ -52,7 +53,7 @@ export class ProfilesService {
     }
 
     getDescription <P extends Profile> (profile: PartialProfile<P>): string|null {
-        profile = this.getConfigProxyForProfile(profile) as PartialProfile<P>
+        profile = this.getConfigProxyForProfile(profile)
         return this.providerForProfile(profile)?.getDescription(profile) ?? null
     }
 
@@ -65,9 +66,9 @@ export class ProfilesService {
     * arg: skipUserDefaults -> do not merge global provider defaults in ConfigProxy
     * arg: skipGroupDefaults -> do not merge parent group provider defaults in ConfigProxy
     */
-    getConfigProxyForProfile <P extends Profile> (profile: PartialProfile<P>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): FullyDefined<P> & ConfigProxy<FullyDefined<P>> {
+    getConfigProxyForProfile <T extends Profile> (profile: PartialProfile<T>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): T {
         const defaults = this.getProfileDefaults(profile, options).reduce(configMerge, {})
-        return new ConfigProxy(profile, defaults) as any
+        return new ConfigProxy(profile, defaults) as unknown as T
     }
 
     /**
@@ -213,10 +214,7 @@ export class ProfilesService {
         const provider = this.providerForProfile(fullProfile)
         const freeInputEquivalent = provider instanceof QuickConnectProfileProvider ? provider.intoQuickConnectString(fullProfile) ?? undefined : undefined
         return {
-            name: profile.name,
-            icon: profile.icon ?? undefined,
-            color: profile.color ?? undefined,
-            weight: profile.weight,
+            ...profile,
             group: this.resolveProfileGroupName(profile.group ?? ''),
             freeInputEquivalent,
             description: provider?.getDescription(fullProfile),
@@ -236,7 +234,7 @@ export class ProfilesService {
                     ...this.selectorOptionForProfile(p),
                     group: this.translate.instant('Recent'),
                     icon: 'fas fa-history',
-                    color: p.color ?? undefined,
+                    color: p.color,
                     weight: i - (recentProfiles.length + 1),
                     callback: async () => {
                         if (p.id) {
@@ -510,7 +508,7 @@ export class ProfilesService {
     * arg: skipUserDefaults -> do not merge global provider defaults in ConfigProxy
     */
     getProviderProfileGroupDefaults (groupId: string, provider: ProfileProvider<Profile>): any {
-        return this.getSyncProfileGroups().find(g => g.id === groupId)?.defaults?.[provider.id] ?? {}
+        return (this.config.store.groups ?? []).find(g => g.id === groupId)?.defaults?.[provider.id] ?? {}
     }
 
 }

--- a/tabby-electron/src/shells/windowsStock.ts
+++ b/tabby-electron/src/shells/windowsStock.ts
@@ -72,21 +72,25 @@ export class WindowsStockShellsProvider extends WindowsBaseShellProvider {
     }
 
     private async getPowerShellPath () {
-        for (const name of ['pwsh.exe', 'powershell.exe']) {
-            if (await which(name, { nothrow: true })) {
-                return name
-            }
-        }
+        // Check well-known paths first to avoid slow PATH scanning via `which`
         for (const psPath of [
             `${process.env.USERPROFILE}\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe`,
+            `${process.env.ProgramFiles}\\PowerShell\\7\\pwsh.exe`,
+            `${process.env['ProgramFiles(x86)']}\\PowerShell\\7\\pwsh.exe`,
             `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
             `${process.env.SystemRoot}\\System32\\powershell.exe`,
-            (process.env.SystemRoot ?? 'C:\\Windows') + '\\powerhshell.exe',
         ]) {
             try {
                 await fs.stat(psPath)
                 return psPath
             } catch { }
+        }
+        // Fall back to PATH search only if not found in standard locations
+        for (const name of ['pwsh.exe', 'powershell.exe']) {
+            const found = await which(name, { nothrow: true })
+            if (found) {
+                return found
+            }
         }
         return 'powershell.exe'
     }

--- a/tabby-electron/src/sshImporters.ts
+++ b/tabby-electron/src/sshImporters.ts
@@ -354,21 +354,43 @@ async function convertToSSHProfiles (config: SSHConfig): Promise<PartialProfile<
 }
 
 
+let _openSSHCache: PartialProfile<SSHProfile>[] | null = null
+let _openSSHCacheMtime: number | null = null
+let _openSSHCachePromise: Promise<PartialProfile<SSHProfile>[]> | null = null
+
 @Injectable({ providedIn: 'root' })
 export class OpenSSHImporter extends SSHProfileImporter {
     async getProfiles (): Promise<PartialProfile<SSHProfile>[]> {
+        if (_openSSHCachePromise) {
+            return _openSSHCachePromise
+        }
 
         const configPath = path.join(process.env.HOME ?? '~', '.ssh', 'config')
 
-        try {
-            const config: SSHConfig = await parseSSHConfigFile(configPath)
-            return await convertToSSHProfiles(config)
-        } catch (e) {
-            if (e.code === 'ENOENT') {
-                return []
+        _openSSHCachePromise = (async () => {
+            try {
+                const stat = await fs.stat(configPath)
+                const mtime = stat.mtimeMs
+
+                if (_openSSHCache && _openSSHCacheMtime === mtime) {
+                    return _openSSHCache
+                }
+
+                const config: SSHConfig = await parseSSHConfigFile(configPath)
+                _openSSHCache = await convertToSSHProfiles(config)
+                _openSSHCacheMtime = mtime
+                return _openSSHCache
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    return []
+                }
+                throw e
+            } finally {
+                _openSSHCachePromise = null
             }
-            throw e
-        }
+        })()
+
+        return _openSSHCachePromise
     }
 }
 

--- a/tabby-electron/src/sshImporters.ts
+++ b/tabby-electron/src/sshImporters.ts
@@ -391,7 +391,7 @@ export class OpenSSHImporter extends SSHProfileImporter {
                 // Try disk cache first
                 try {
                     const diskCache: SSHProfileDiskCache = JSON.parse(
-                        await fs.readFile(this.diskCachePath, 'utf8')
+                        await fs.readFile(this.diskCachePath, 'utf8'),
                     )
                     if (diskCache.mtime === mtime) {
                         _openSSHCache = diskCache.profiles

--- a/tabby-electron/src/sshImporters.ts
+++ b/tabby-electron/src/sshImporters.ts
@@ -358,8 +358,20 @@ let _openSSHCache: PartialProfile<SSHProfile>[] | null = null
 let _openSSHCacheMtime: number | null = null
 let _openSSHCachePromise: Promise<PartialProfile<SSHProfile>[]> | null = null
 
+interface SSHProfileDiskCache {
+    mtime: number
+    profiles: PartialProfile<SSHProfile>[]
+}
+
 @Injectable({ providedIn: 'root' })
 export class OpenSSHImporter extends SSHProfileImporter {
+    private diskCachePath: string
+
+    constructor (electron: ElectronService) {
+        super()
+        this.diskCachePath = path.join(electron.app.getPath('userData'), 'ssh-profiles-cache.json')
+    }
+
     async getProfiles (): Promise<PartialProfile<SSHProfile>[]> {
         if (_openSSHCachePromise) {
             return _openSSHCachePromise
@@ -376,9 +388,26 @@ export class OpenSSHImporter extends SSHProfileImporter {
                     return _openSSHCache
                 }
 
+                // Try disk cache first
+                try {
+                    const diskCache: SSHProfileDiskCache = JSON.parse(
+                        await fs.readFile(this.diskCachePath, 'utf8')
+                    )
+                    if (diskCache.mtime === mtime) {
+                        _openSSHCache = diskCache.profiles
+                        _openSSHCacheMtime = mtime
+                        return _openSSHCache
+                    }
+                } catch { /* no cache or invalid */ }
+
                 const config: SSHConfig = await parseSSHConfigFile(configPath)
                 _openSSHCache = await convertToSSHProfiles(config)
                 _openSSHCacheMtime = mtime
+
+                // Save to disk cache (fire and forget)
+                fs.writeFile(this.diskCachePath, JSON.stringify({ mtime, profiles: _openSSHCache }))
+                    .catch(() => { /* ignore write errors */ })
+
                 return _openSSHCache
             } catch (e) {
                 if (e.code === 'ENOENT') {

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -75,7 +75,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
             base = await this.selector.show(
                 this.translate.instant('Select a base profile to use as a template'),
                 profiles.map(p => ({
-                    icon: p.icon,
+                    icon: p.icon ?? undefined,
                     description: this.profilesService.getDescription(p) ?? undefined,
                     name: p.group ? `${this.profilesService.resolveProfileGroupName(p.group)} / ${p.name}` : p.name,
                     result: p,

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -26,6 +26,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     profileGroups: PartialProfileGroup<CollapsableProfileGroup>[]
     filter = ''
     Platform = Platform
+    private descriptionCache = new Map<string, string|null>()
 
     constructor (
         public config: ConfigService,
@@ -49,10 +50,17 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     }
 
     async refreshProfiles (): Promise<void> {
-        this.builtinProfiles = (await this.profilesService.getProfiles()).filter(x => x.isBuiltin)
-        this.customProfiles = (await this.profilesService.getProfiles()).filter(x => !x.isBuiltin)
-        this.templateProfiles = this.builtinProfiles.filter(x => x.isTemplate)
-        this.builtinProfiles = this.builtinProfiles.filter(x => !x.isTemplate)
+        const allProfiles = await this.profilesService.getProfiles()
+        this.builtinProfiles = allProfiles.filter(x => x.isBuiltin && !x.isTemplate)
+        this.templateProfiles = allProfiles.filter(x => x.isBuiltin && x.isTemplate)
+        this.customProfiles = allProfiles.filter(x => !x.isBuiltin)
+
+        this.descriptionCache.clear()
+        for (const p of allProfiles) {
+            if (p.id) {
+                this.descriptionCache.set(p.id, this.profilesService.getDescription(p))
+            }
+        }
     }
 
     launchProfile (profile: PartialProfile<Profile>): void {
@@ -67,7 +75,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
             base = await this.selector.show(
                 this.translate.instant('Select a base profile to use as a template'),
                 profiles.map(p => ({
-                    icon: p.icon ?? undefined,
+                    icon: p.icon,
                     description: this.profilesService.getDescription(p) ?? undefined,
                     name: p.group ? `${this.profilesService.resolveProfileGroupName(p.group)} / ${p.name}` : p.name,
                     result: p,
@@ -265,6 +273,9 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     }
 
     getDescription (profile: PartialProfile<Profile>): string|null {
+        if (profile.id) {
+            return this.descriptionCache.get(profile.id) ?? null
+        }
         return this.profilesService.getDescription(profile)
     }
 


### PR DESCRIPTION
Add mtime-based cache with Promise deduplication to OpenSSHImporter  to avoid re-parsing ~/.ssh/config on every change detection cycle.

To test, create ~1k fake hosts in ~/.ssh/config and measure the loading time of the profile list.

upd:
Performance: avoid redundant DOM updates — HTML binding directive now skips re-rendering when the value hasn't changed, reducing unnecessary DOM manipulation during change detection cycles.

Performance: profile descriptions computed once per refresh — profile descriptions are now cached after each profile list refresh instead of being recomputed on every render, which is significant when the list is large or descriptions are expensive to resolve.

Performance: profile list loaded once per refresh — the profiles settings page now fetches the full profile list once instead of twice when refreshing.

Performance: faster PowerShell detection on Windows — well-known installation paths are checked first before falling back to a full PATH scan, reducing startup latency on Windows.

Performance: SSH config parsing cached to disk — parsed SSH profiles are persisted to a local JSON cache keyed by the config file's modification time. On subsequent loads, if the file hasn't changed, the cache is used instead of re-parsing, speeding up startup when the SSH config is large.

Correctness: profile selector includes all profile fields — when building selector options from a profile, all profile fields are now forwarded instead of a manually maintained subset, preventing fields from being silently dropped as the profile schema evolves.

Correctness: added missing default field for terminal color scheme — the profile defaults object now explicitly includes terminalColorScheme, ensuring it is always present when profiles are merged.