### PR TITLE
feat(ssh): add hotkey to open SFTP panel

### DIFF
--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -64,6 +64,9 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
                         this.ssh.launchWinSCP(this.sshSession)
                     }
                     break
+                case 'open-sftp':
+                    this.openSFTP()
+                    break
             }
         })
 

--- a/tabby-ssh/src/config.ts
+++ b/tabby-ssh/src/config.ts
@@ -15,6 +15,7 @@ export class SSHConfigProvider extends ConfigProvider {
         hotkeys: {
             'restart-ssh-session': [],
             'launch-winscp': [],
+            'open-sftp': [],
         },
     }
 

--- a/tabby-ssh/src/hotkeys.ts
+++ b/tabby-ssh/src/hotkeys.ts
@@ -13,6 +13,10 @@ export class SSHHotkeyProvider extends HotkeyProvider {
             id: 'launch-winscp',
             name: this.translate.instant('Launch WinSCP for current SSH session'),
         },
+        {
+            id: 'open-sftp',
+            name: this.translate.instant('Open SFTP panel'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }


### PR DESCRIPTION
## Summary
This PR implements a keyboard shortcut to open the SFTP panel for active SSH sessions, as requested in #8461.
## Changes
- Registered `open-sftp` hotkey in the SSH plugin.
- Added a hotkey listener in `SSHTabComponent` to trigger `openSFTP()`.
## Fixes
Fixes #8461