### PR TITLE
fix: disable spellchecker to prevent automatic dictionary downloads

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -152,6 +152,7 @@ export class Window {
         this.window.webContents.setZoomFactor(1)
         this.window.webContents.session.setPermissionCheckHandler(() => true)
         this.window.webContents.session.setDevicePermissionHandler(() => true)
+        this.window.webContents.session.setSpellCheckerEnabled(false)
 
         if (process.platform === 'darwin') {
             this.touchBarControl = new TouchBar.TouchBarSegmentedControl({


### PR DESCRIPTION
## Summary
This PR disables Electron's built-in spellchecker to prevent it from automatically downloading dictionary files from Google's servers. This addresses privacy and bandwidth concerns raised by users who want to minimize background network activity.
## Changes
 - Added this.window.webContents.session.setSpellCheckerEnabled(false) in tabby/app/lib/window.ts to globally disable the spellchecker for the application window's session.
 
 ## Fixes: 
 Fixes #10976 