### PR TITLE
feat: add 'Export to file' option to terminal context menu

### DIFF
--- a/tabby-electron/src/index.ts
+++ b/tabby-electron/src/index.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core'
-import { PlatformService, LogService, UpdaterService, DockingService, HostAppService, ThemesService, Platform, AppService, ConfigService, WIN_BUILD_FLUENT_BG_SUPPORTED, isWindowsBuild, HostWindowService, HotkeyProvider, ConfigProvider, FileProvider } from 'tabby-core'
+import { PlatformService, LogService, UpdaterService, DockingService, HostAppService, ThemesService, Platform, AppService, ConfigService, WIN_BUILD_FLUENT_BG_SUPPORTED, isWindowsBuild, HostWindowService, HotkeyProvider, ConfigProvider, FileProvider, TabContextMenuItemProvider } from 'tabby-core'
 import { TerminalColorSchemeProvider, TerminalDecorator } from 'tabby-terminal'
 import { SFTPContextMenuItemProvider, SSHProfileImporter, AutoPrivateKeyLocator } from 'tabby-ssh'
 import { PTYInterface, ShellProvider, UACService } from 'tabby-local'
@@ -21,6 +21,7 @@ import { ElectronUACService } from './services/uac.service'
 import { ElectronHotkeyProvider } from './hotkeys'
 import { ElectronConfigProvider } from './config'
 import { EditSFTPContextMenu } from './sftpContextMenu'
+import { ExportTerminalContextMenu } from './terminalContextMenu'
 import { OpenSSHImporter, PrivateKeyLocator, StaticFileImporter } from './sshImporters'
 import { ElectronPTYInterface } from './pty'
 import { PathDropDecorator } from './pathDrop'
@@ -75,6 +76,8 @@ import { VSDevToolsProvider } from './shells/vs'
         { provide: PTYInterface, useClass: ElectronPTYInterface },
 
         { provide: TerminalDecorator, useClass: PathDropDecorator, multi: true },
+
+        { provide: TabContextMenuItemProvider, useClass: ExportTerminalContextMenu, multi: true },
 
         // For WindowsDefaultShellProvider
         PowerShellCoreShellProvider,

--- a/tabby-electron/src/index.ts
+++ b/tabby-electron/src/index.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core'
-import { PlatformService, LogService, UpdaterService, DockingService, HostAppService, ThemesService, Platform, AppService, ConfigService, WIN_BUILD_FLUENT_BG_SUPPORTED, isWindowsBuild, HostWindowService, HotkeyProvider, ConfigProvider, FileProvider, TabContextMenuItemProvider } from 'tabby-core'
-import { TerminalColorSchemeProvider, TerminalDecorator } from 'tabby-terminal'
+import { PlatformService, LogService, UpdaterService, DockingService, HostAppService, ThemesService, Platform, AppService, ConfigService, WIN_BUILD_FLUENT_BG_SUPPORTED, isWindowsBuild, HostWindowService, HotkeyProvider, ConfigProvider, FileProvider } from 'tabby-core'
+import { TerminalColorSchemeProvider, TerminalContextMenuItemProvider, TerminalDecorator } from 'tabby-terminal'
 import { SFTPContextMenuItemProvider, SSHProfileImporter, AutoPrivateKeyLocator } from 'tabby-ssh'
 import { PTYInterface, ShellProvider, UACService } from 'tabby-local'
 import { auditTime } from 'rxjs'
@@ -77,7 +77,7 @@ import { VSDevToolsProvider } from './shells/vs'
 
         { provide: TerminalDecorator, useClass: PathDropDecorator, multi: true },
 
-        { provide: TabContextMenuItemProvider, useClass: ExportTerminalContextMenu, multi: true },
+        { provide: TerminalContextMenuItemProvider, useClass: ExportTerminalContextMenu, multi: true },
 
         // For WindowsDefaultShellProvider
         PowerShellCoreShellProvider,

--- a/tabby-electron/src/terminalContextMenu.ts
+++ b/tabby-electron/src/terminalContextMenu.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs'
+import { Injectable } from '@angular/core'
+import { BaseTabComponent, MenuItemOptions, NotificationsService, TabContextMenuItemProvider, TranslateService } from 'tabby-core'
+import { BaseTerminalTabComponent } from 'tabby-terminal'
+import { ElectronService } from './services/electron.service'
+
+/** @hidden */
+@Injectable()
+export class ExportTerminalContextMenu extends TabContextMenuItemProvider {
+    weight = 0
+
+    constructor (
+        private electron: ElectronService,
+        private notifications: NotificationsService,
+        private translate: TranslateService,
+    ) {
+        super()
+    }
+
+    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
+        if (!(tab instanceof BaseTerminalTabComponent)) {
+            return []
+        }
+
+        return [
+            {
+                label: this.translate.instant('Export to file'),
+                click: async () => {
+                    const frontend = tab.frontend
+                    if (!frontend) {
+                        return
+                    }
+                    const result = await this.electron.dialog.showSaveDialog({
+                        defaultPath: 'terminal.txt',
+                    })
+                    if (!result.filePath) {
+                        return
+                    }
+                    frontend.selectAll()
+                    const content = frontend.getSelection()
+                    frontend.clearSelection()
+                    await fs.promises.writeFile(result.filePath, content)
+                    this.notifications.info(this.translate.instant('Saved to {path}', { path: result.filePath }))
+                },
+            },
+        ]
+    }
+}

--- a/tabby-electron/src/terminalContextMenu.ts
+++ b/tabby-electron/src/terminalContextMenu.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs'
 import { Injectable } from '@angular/core'
-import { BaseTabComponent, MenuItemOptions, NotificationsService, TabContextMenuItemProvider, TranslateService } from 'tabby-core'
-import { BaseTerminalTabComponent } from 'tabby-terminal'
+import { MenuItemOptions, NotificationsService, TranslateService } from 'tabby-core'
+import { BaseTerminalTabComponent, TerminalContextMenuItemProvider } from 'tabby-terminal'
 import { ElectronService } from './services/electron.service'
 
 /** @hidden */
 @Injectable()
-export class ExportTerminalContextMenu extends TabContextMenuItemProvider {
+export class ExportTerminalContextMenu extends TerminalContextMenuItemProvider {
     weight = 0
 
     constructor (
@@ -17,11 +17,7 @@ export class ExportTerminalContextMenu extends TabContextMenuItemProvider {
         super()
     }
 
-    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
-        if (!(tab instanceof BaseTerminalTabComponent)) {
-            return []
-        }
-
+    async getItems (tab: BaseTerminalTabComponent<any>): Promise<MenuItemOptions[]> {
         return [
             {
                 label: this.translate.instant('Export to file'),

--- a/tabby-terminal/src/index.ts
+++ b/tabby-terminal/src/index.ts
@@ -29,7 +29,7 @@ import { DebugDecorator } from './features/debug'
 import { ZModemDecorator } from './features/zmodem'
 import { TerminalConfigProvider } from './config'
 import { TerminalHotkeyProvider } from './hotkeys'
-import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu, SaveAsProfileContextMenu, ExportContextMenu } from './tabContextMenu'
+import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu, SaveAsProfileContextMenu } from './tabContextMenu'
 
 import { Frontend } from './frontends/frontend'
 import { XTermFrontend, XTermWebGLFrontend } from './frontends/xtermFrontend'
@@ -61,7 +61,6 @@ import { DefaultColorSchemes } from './colorSchemes'
         { provide: TabContextMenuItemProvider, useClass: LegacyContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: ReconnectContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: SaveAsProfileContextMenu, multi: true },
-        { provide: TabContextMenuItemProvider, useClass: ExportContextMenu, multi: true },
 
         { provide: CLIHandler, useClass: TerminalCLIHandler, multi: true },
         { provide: TerminalColorSchemeProvider, useClass: DefaultColorSchemes, multi: true },

--- a/tabby-terminal/src/index.ts
+++ b/tabby-terminal/src/index.ts
@@ -29,7 +29,7 @@ import { DebugDecorator } from './features/debug'
 import { ZModemDecorator } from './features/zmodem'
 import { TerminalConfigProvider } from './config'
 import { TerminalHotkeyProvider } from './hotkeys'
-import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu, SaveAsProfileContextMenu } from './tabContextMenu'
+import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu, SaveAsProfileContextMenu, ExportContextMenu } from './tabContextMenu'
 
 import { Frontend } from './frontends/frontend'
 import { XTermFrontend, XTermWebGLFrontend } from './frontends/xtermFrontend'
@@ -61,6 +61,7 @@ import { DefaultColorSchemes } from './colorSchemes'
         { provide: TabContextMenuItemProvider, useClass: LegacyContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: ReconnectContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: SaveAsProfileContextMenu, multi: true },
+        { provide: TabContextMenuItemProvider, useClass: ExportContextMenu, multi: true },
 
         { provide: CLIHandler, useClass: TerminalCLIHandler, multi: true },
         { provide: TerminalColorSchemeProvider, useClass: DefaultColorSchemes, multi: true },

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,13 +1,12 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile, ElectronService } from 'tabby-core'
+import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
 import { ConnectableTerminalTabComponent } from './api/connectableTerminalTab.component'
 import { v4 as uuidv4 } from 'uuid'
 import slugify from 'slugify'
-import * as fs from 'fs'
 
 /** @hidden */
 @Injectable()
@@ -216,39 +215,3 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
     }
 }
 
-/** @hidden */
-@Injectable()
-export class ExportContextMenu extends TabContextMenuItemProvider {
-    weight = 0
-
-    constructor (
-        private electron: ElectronService,
-        private notifications: NotificationsService,
-        private translate: TranslateService,
-    ) {
-        super()
-    }
-
-    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
-        if (tab instanceof BaseTerminalTabComponent) {
-            return [
-                {
-                    label: this.translate.instant('Export to file'),
-                    click: async () => {
-                        const result = await this.electron.dialog.showSaveDialog({
-                            defaultPath: 'terminal.txt',
-                        })
-                        if (result.filePath) {
-                            tab.frontend.selectAll()
-                            const content = tab.frontend.getSelection()
-                            tab.frontend.clearSelection()
-                            await fs.promises.writeFile(result.filePath, content)
-                            this.notifications.info(this.translate.instant('Saved to {path}', { path: result.filePath }))
-                        }
-                    },
-                },
-            ]
-        }
-        return []
-    }
-}

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,12 +1,13 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile } from 'tabby-core'
+import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile, ElectronService } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
 import { ConnectableTerminalTabComponent } from './api/connectableTerminalTab.component'
 import { v4 as uuidv4 } from 'uuid'
 import slugify from 'slugify'
+import * as fs from 'fs'
 
 /** @hidden */
 @Injectable()
@@ -211,6 +212,43 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
             ]
         }
 
+        return []
+    }
+}
+
+/** @hidden */
+@Injectable()
+export class ExportContextMenu extends TabContextMenuItemProvider {
+    weight = 0
+
+    constructor (
+        private electron: ElectronService,
+        private notifications: NotificationsService,
+        private translate: TranslateService,
+    ) {
+        super()
+    }
+
+    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
+        if (tab instanceof BaseTerminalTabComponent) {
+            return [
+                {
+                    label: this.translate.instant('Export to file'),
+                    click: async () => {
+                        const result = await this.electron.dialog.showSaveDialog({
+                            defaultPath: 'terminal.txt',
+                        })
+                        if (result.filePath) {
+                            tab.frontend.selectAll()
+                            const content = tab.frontend.getSelection()
+                            tab.frontend.clearSelection()
+                            await fs.promises.writeFile(result.filePath, content)
+                            this.notifications.info(this.translate.instant('Saved to {path}', { path: result.filePath }))
+                        }
+                    },
+                },
+            ]
+        }
         return []
     }
 }


### PR DESCRIPTION
## Description
This PR introduces a new "Export to file" option in the terminal's right-click context menu. This allows users to easily save the entire terminal scrollback buffer to a local text file using the system's native "Save" dialog.

## Changes
- Created a new ExportContextMenu provider in tabby-terminal/src/tabContextMenu.ts.
- The provider uses the selectAll() and getSelection() methods of the terminal frontend to capture the buffer content.
- Leverages Electron's dialog.showSaveDialog to prompt the user for a file location.
- Registered the new provider in tabby-terminal/src/index.ts.
- Moved Export-to-file terminal context menu into tabby-electron (electron-only) and added frontend null guard. 
- Pushed commit 2423c3aa to feat/export-terminal-to-file.

## Fixes
Fixes #7563 