### PR TITLE
docs: add tabby-ssh-keymap to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Plugins and themes can be installed directly from the Settings view inside Tabby
 * [highlight](https://github.com/moemoechu/tabby-highlight) - Tabby terminal keyword highlight plugin
 * [web-auth-handler](https://github.com/Jazzmoon/tabby-web-auth-handler) - In-app web authentication popups (Built primarily for warpgate in-browser auth)
 * [mcp-server](https://github.com/thuanpham582002/tabby-mcp-server) - Powerful Model Context Protocol server integration for Tabby that seamlessly connects with AI assistants through MCP clients like Cursor and Windsurf, enhancing your terminal workflow with intelligent AI capabilities.
+* [ssh-keymap](https://github.com/mathys-lopinto/tabby-ssh-keymap) - lets your synced Tabby SSH profiles reference private keys by name instead of by absolute file path. A local mapping file (never synced) translates each name to the real path on that machine
 
 <a name="themes"></a>
 


### PR DESCRIPTION
## Add `tabby-ssh-keymap` to the plugins list

This PR adds [tabby-ssh-keymap](https://github.com/mathys-lopinto/tabby-ssh-keymap) to the community plugins section.

### What it does

Adds an indirection layer between Tabby SSH profiles and the physical paths of your private keys. Instead of hardcoding `file:///home/alice/.ssh/id_work` in every profile, profiles reference a logical name like `sshkey://work`, and each machine keeps a local, never-synced keymap file that resolves that name to the actual path.

### Why

Tabby's config sync is great, but SSH profiles with absolute key paths break the moment you sync to a machine with a different username or OS (`/home/alice/...` vs `C:\Users\Alice\...` vs `/Users/alice/...`). This plugin solves that without giving up config sync.

As a bonus, it also gives you a single source of truth for key paths locally — rotating a key or reorganizing `~/.ssh/` is a one-line edit in the keymap; every profile referencing that name follows automatically.

### Features

- One-click migration of existing `file://` entries in SSH profiles to `sshkey://`
- Cascade rename: renaming a key updates every profile that references it
- Key validation via `russh` parsing
- `~/` home expansion
- Search & per-key usage count in the settings UI
- Fully backward compatible — existing `file://` paths keep working

### Links

- npm: https://www.npmjs.com/package/tabby-ssh-keymap
- Repo: https://github.com/mathys-lopinto/tabby-ssh-keymap
- License: MIT