### PR TITLE
feat(ssh): pre-populate vault password in auth prompts for MFA (fixes #9911)

### DIFF
--- a/tabby-ssh/src/components/keyboardInteractiveAuthPanel.component.ts
+++ b/tabby-ssh/src/components/keyboardInteractiveAuthPanel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, ViewChild, ElementRef, ChangeDetectionStrategy } from '@angular/core'
+import { Component, Input, Output, EventEmitter, ViewChild, ElementRef, ChangeDetectionStrategy, OnInit, ChangeDetectorRef } from '@angular/core'
 import { KeyboardInteractivePrompt } from '../session/ssh'
 import { SSHProfile } from '../api'
 import { PasswordStorageService } from '../services/passwordStorage.service'
@@ -9,7 +9,7 @@ import { PasswordStorageService } from '../services/passwordStorage.service'
     styleUrls: ['./keyboardInteractiveAuthPanel.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class KeyboardInteractiveAuthComponent {
+export class KeyboardInteractiveAuthComponent implements OnInit {
     @Input() profile: SSHProfile
     @Input() prompt: KeyboardInteractivePrompt
     @Input() step = 0
@@ -17,7 +17,22 @@ export class KeyboardInteractiveAuthComponent {
     @ViewChild('input') input: ElementRef
     remember = false
 
-    constructor (private passwordStorage: PasswordStorageService) {}
+    constructor (
+        private passwordStorage: PasswordStorageService,
+        private cdr: ChangeDetectorRef,
+    ) {}
+
+    async ngOnInit (): Promise<void> {
+        const savedPassword = await this.passwordStorage.loadPassword(this.profile)
+        if (savedPassword) {
+            for (let i = 0; i < this.prompt.prompts.length; i++) {
+                if (this.prompt.isAPasswordPrompt(i) && !this.prompt.responses[i]) {
+                    this.prompt.responses[i] = savedPassword
+                }
+            }
+            this.cdr.markForCheck()
+        }
+    }
 
     isPassword (): boolean {
         return this.prompt.isAPasswordPrompt(this.step)

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -657,7 +657,7 @@ export class SSHSession {
                 modal.componentInstance.prompt = `Password for ${this.authUsername}@${this.profile.options.host}`
                 modal.componentInstance.password = true
                 modal.componentInstance.showRememberCheckbox = true
-                const prefilledPassword = await this.passwordStorage.loadPassword(this.profile, this.authUsername ?? undefined)
+                const prefilledPassword = await this.passwordStorage.loadPassword(this.profile, this.authUsername)
                 if (prefilledPassword) {
                     modal.componentInstance.value = prefilledPassword
                 }

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -657,6 +657,10 @@ export class SSHSession {
                 modal.componentInstance.prompt = `Password for ${this.authUsername}@${this.profile.options.host}`
                 modal.componentInstance.password = true
                 modal.componentInstance.showRememberCheckbox = true
+                const prefilledPassword = await this.passwordStorage.loadPassword(this.profile, this.authUsername ?? undefined)
+                if (prefilledPassword) {
+                    modal.componentInstance.value = prefilledPassword
+                }
 
                 try {
                     const promptResult = await modal.result.catch(() => null)


### PR DESCRIPTION
## Summary

- Pre-fills vault password in keyboard-interactive password prompts when the response field is empty, so users with hardware tokens (e.g. YubiKey) can append a TOTP to the pre-filled base password without re-typing it
- Pre-fills the prompt-password modal with the vault password for the same MFA workflow when SSH password auth is used

## Changes

**`tabby-ssh/src/components/keyboardInteractiveAuthPanel.component.ts`**
- Implements `OnInit` to load the vault password on component init
- For each prompt identified as a password prompt with an empty response, populates it from the vault
- Calls `ChangeDetectorRef.markForCheck()` to ensure the `OnPush` component re-renders with the pre-filled value

**`tabby-ssh/src/session/ssh.ts`**
- Before opening the `prompt-password` modal, loads the vault password and sets it as the initial `value` on the modal instance

## Use case (from issue #9911)

Users with RSA-style YubiKey MFA need to enter `<base-password><TOTP>`. With the vault storing just the base password, this change pre-fills the auth prompt so users only need to press their YubiKey token to append the TOTP and submit.

## Test plan

- [ ] Connect to an SSH server using keyboard-interactive auth with a vault-stored password — confirm the password field is pre-filled
- [ ] Press YubiKey / append TOTP to the pre-filled value and confirm authentication succeeds
- [ ] Confirm that prompts without a vault password still show an empty field
- [ ] Confirm that already-populated responses (from `method.savedPassword`) are not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)