### PR TITLE
fix(ssh): support OTP 2FA when auth mode is set to Password

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -280,7 +280,7 @@ export class SSHSession {
             }
         }
 
-        if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive') {
+        if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive' || this.profile.options.auth === 'password') {
             const existingSaved = this.allAuthMethods.find(method => method.type === 'keyboard-interactive' && method.savedPassword === storedPassword)
             if (!existingSaved) {
                 const updatable = this.allAuthMethods.find(method => method.type === 'keyboard-interactive' && method.savedPassword === undefined)

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -249,7 +249,7 @@ export class SSHSession {
                 this.allAuthMethods.push({ type: 'saved-password', password: this.profile.options.password })
             }
         }
-        if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive') {
+        if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive' || this.profile.options.auth === 'password') {
             if (this.profile.options.password) {
                 this.allAuthMethods.push({ type: 'keyboard-interactive', savedPassword: this.profile.options.password })
             }


### PR DESCRIPTION
Include keyboard-interactive auth method when auth is explicitly set to 'password'. Previously, keyboard-interactive was only included for 'auto' or 'keyboardInteractive' modes, causing OTP/2FA challenges to fail with 'Authentication rejected' when the user selected Password mode. This allows password auth to fall through to keyboard-interactive when the server requires a second factor.

当用户在 profile 设置中显式选择 "Password" 认证模式时，keyboard-interactive 也会被加入认证方法列表。这样当密码认证被服务器拒绝（因为需要 OTP），可以自动 fallthrough 到 keyboard-interactive 流程弹出 OTP 输入框，不再直接报 Authentication rejected