### PR TITLE
Add option to replace line breaks with spaces on paste

### DIFF
--- a/locale/app.pot
+++ b/locale/app.pot
@@ -2313,6 +2313,14 @@ msgstr ""
 msgid "Trim whitespace and newlines"
 msgstr ""
 
+#: locale/tmp-html/tabby-terminal/src/components/terminalSettingsTab.component.html:120
+msgid "Replace line breaks with spaces"
+msgstr ""
+
+#: locale/tmp-html/tabby-terminal/src/components/terminalSettingsTab.component.html:121
+msgid "Flatten pasted text into a single line for terminals that do not support multiline paste"
+msgstr ""
+
 #: tabby-core/src/services/config.service.ts:428
 msgid "Try again"
 msgstr ""

--- a/locale/es-ES.po
+++ b/locale/es-ES.po
@@ -1720,6 +1720,14 @@ msgstr "Recordar por {time}"
 msgid "Remote"
 msgstr "Remoto"
 
+#: locale/tmp-html/tabby-terminal/src/components/terminalSettingsTab.component.html:120
+msgid "Replace line breaks with spaces"
+msgstr "Reemplazar los saltos de línea por espacios"
+
+#: locale/tmp-html/tabby-terminal/src/components/terminalSettingsTab.component.html:121
+msgid "Flatten pasted text into a single line for terminals that do not support multiline paste"
+msgstr "Aplanar el texto pegado en una sola línea para terminales que no admiten pegado multilínea"
+
 #: locale/tmp-html/tabby-terminal/src/components/terminalSettingsTab.component.html:124
 msgid "Remove whitespace and newlines around the copied text"
 msgstr "Eliminar espacios en blanco y nuevas líneas alrededor del texto copiado"

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -535,6 +535,10 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             data = data.replaceAll('\n', '\r')
         }
 
+        if (this.config.store.terminal.replaceNewlinesWithSpacesOnPaste) {
+            data = data.replace(/[\r\n]+/g, ' ')
+        }
+
         if (this.config.store.terminal.trimWhitespaceOnPaste && data.indexOf('\n') === data.length - 1) {
             // Ends with a newline and has no other line breaks
             data = data.substring(0, data.length - 1)

--- a/tabby-terminal/src/components/terminalSettingsTab.component.pug
+++ b/tabby-terminal/src/components/terminalSettingsTab.component.pug
@@ -155,6 +155,15 @@ div.mt-4
 
     .form-line
         .header
+            .title(translate) Replace line breaks with spaces
+            .description(translate) Flatten pasted text into a single line for terminals that do not support multiline paste
+        toggle(
+            [(ngModel)]='config.store.terminal.replaceNewlinesWithSpacesOnPaste',
+            (ngModelChange)='config.save()',
+        )
+
+    .form-line
+        .header
             .title(translate) Trim whitespace and newlines
             .description(translate) Remove whitespace and newlines around the copied text
         toggle(

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -52,6 +52,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             drawBoldTextInBrightColors: true,
             sixel: true,
             minimumContrastRatio: 4,
+            replaceNewlinesWithSpacesOnPaste: false,
             trimWhitespaceOnPaste: true,
         },
     }


### PR DESCRIPTION
It is a simple addition because when there is no support for multi-line pasting in the shell and you use this for Claude Code or OpenCode, it becomes a problem to paste something with line breaks without it being sent as an "enter"
I don't really know if it's completely necessary, but it's useful in many cases so you don't have to be correcting it in a notepad