### PR TITLE
fix: persist new SSH profiles from settings

### DIFF
--- a/tabby-settings/src/components/editProfileModal.component.ts
+++ b/tabby-settings/src/components/editProfileModal.component.ts
@@ -2,7 +2,7 @@
 import { Observable, OperatorFunction, debounceTime, map, distinctUntilChanged } from 'rxjs'
 import { Component, Input, ViewChild, ViewContainerRef, ComponentFactoryResolver, Injector } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { PartialProfileGroup, Profile, ProfileProvider, ProfileSettingsComponent, ProfilesService, TAB_COLORS, ProfileGroup, ConnectableProfileProvider, FullyDefined, ConfigProxy } from 'tabby-core'
+import { PartialProfile, PartialProfileGroup, Profile, ProfileProvider, ProfileSettingsComponent, ProfilesService, TAB_COLORS, ProfileGroup, ConnectableProfileProvider, FullyDefined, ConfigProxy } from 'tabby-core'
 
 const iconsData = require('../../../tabby-core/src/icons.json')
 const iconsClassList = Object.keys(iconsData).map(
@@ -95,8 +95,10 @@ export class EditProfileModalComponent<P extends Profile, PP extends ProfileProv
         }
 
         this.settingsComponentInstance?.save?.()
-        this.profile.__cleanup()
-        this.modalInstance.close(this.partialProfile)
+        if (typeof this.profile.__cleanup === 'function') {
+            this.profile.__cleanup()
+        }
+        this.modalInstance.close(JSON.parse(JSON.stringify(this.profile)) as PartialProfile<P>)
     }
 
     cancel () {

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -38,9 +38,12 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
         this.jumpHosts = (await this.profilesService.getProfiles({ includeBuiltin: false })).filter(x => x.type === 'ssh' && x !== this.profile)
         this.jumpHosts.sort(firstBy(x => this.getJumpHostLabel(x)))
 
+        const configuredAlgorithmsByType = this.profile.options.algorithms as Partial<Record<SSHAlgorithmType, string[]>> | undefined
         for (const k of Object.values(SSHAlgorithmType)) {
             this.algorithms[k] = {}
-            for (const alg of this.profile.options.algorithms[k]) {
+            const configuredAlgorithms = configuredAlgorithmsByType?.[k]
+            const selectedAlgorithms = Array.isArray(configuredAlgorithms) ? configuredAlgorithms : []
+            for (const alg of selectedAlgorithms) {
                 this.algorithms[k][alg] = true
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes a set of regressions in the profile editor that broke SSH profile creation/editing on Windows.

## Reproduction

1. Open Tabby on Windows.
2. Go to Settings -> Profiles & connections.
3. Create a new SSH profile or edit an existing one created from older config data.
4. Click Save.

Observed behavior before this change:

- The editor could throw `this.profile.options.algorithms[k] is not iterable` when legacy profiles contained `algorithms: {}`.
- The editor could throw `this.profile.__cleanup is not a function` when saving a newly created profile.
- After the crashes were avoided, the modal could still close without persisting the new profile, so the item never appeared in the list.

## Root cause

There were three separate issues in the save path:

1. `tabby-ssh/src/components/sshProfileSettings.component.ts` assumed every `profile.options.algorithms[k]` value was an iterable array.
2. `tabby-settings/src/components/editProfileModal.component.ts` unconditionally called `profile.__cleanup()` even when the edited object did not expose that helper.
3. The profile edit modal returned the stale original profile object instead of a serialized snapshot of the edited proxy-backed state, so newly created profiles were not persisted.

## Fix

- Normalize `profile.options.algorithms` during SSH profile editor initialization and tolerate legacy non-array values by treating them as empty algorithm selections.
- Guard the optional `profile.__cleanup()` call before invoking it.
- Return a serialized snapshot of the edited profile from the modal, so the caller receives the actual saved values for new profile creation.

## Validation

- Ran targeted `eslint` on:
  - `tabby-settings/src/components/editProfileModal.component.ts`
  - `tabby-ssh/src/components/sshProfileSettings.component.ts`
- Verified end-to-end locally on Windows:
  - create a new SSH profile
  - click Save
  - confirm the new item appears in the profile list

## Notes

Broader repository lint/typecheck currently reports unrelated baseline dependency/type issues in this environment, so validation for this change was kept focused on the touched files plus local end-to-end behavior.