### PR TITLE
Fix CLI crashes on Wayland due to unhandled X11 error in Glasstron

### DIFF
--- a/patches/glasstron+0.1.1.patch
+++ b/patches/glasstron+0.1.1.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/glasstron/src/native/linux_x11/x11.js b/node_modules/glasstron/src/native/linux_x11/x11.js
+index e38682a..5a9f214 100644
+--- a/node_modules/glasstron/src/native/linux_x11/x11.js
++++ b/node_modules/glasstron/src/native/linux_x11/x11.js
+@@ -58,10 +58,16 @@ class X11Connection {
+ 				id = this.display.screen[0].root;
+ 
+ 			this.display.client.GetProperty(0, id, prop, 0, 0, 10000000, (err, propData) => {
+-				if(err) console.error(err);
++				if(err) {
++					console.error(err);
++					return reject(err);
++				}
+ 
+ 				this.display.client.GetAtomName(propData.type, (err, typeName) => {
+-					if(err) console.error(err);
++					if(err) {
++						console.error(err);
++						return reject(err);
++					}
+ 
+ 					propData.typeName = typeName;
+ 					resolve(propData);


### PR DESCRIPTION
**The Problem:**
When running Tabby CLI commands (like `tabby profile "default"`) on a Wayland session, the CLI process frequently crashes before it can send the command to the singleton instance. This results in the CLI hanging and a redundant Tabby window being spawned.

**Root Cause:**
The crash originates in the `glasstron` dependency: `node_modules/glasstron/src/native/linux_x11/x11.js`. 
On Wayland/XWayland, `GetProperty` occasionally fails and returns an `err`. However, `glasstron` logs the error and continues execution. It then crashes on the next line when it attempts to read `propData.type` (since `propData` is `undefined`).

```javascript
// Current broken implementation in glasstron
this.display.client.GetProperty(0, id, prop, 0, 0, 10000000, (err, propData) => {
    if(err) console.error(err); // <-- Does not return/reject!

    // Crashes here: TypeError: Cannot read properties of undefined (reading 'type')
    this.display.client.GetAtomName(propData.type, (err, typeName) => { 
```

**The Solution:**
Since the original `glasstron` repository appears to be abandoned (NPM lists it as deprecated/unsupported and the GitHub repo returns a 404), this PR applies the fix directly via `patch-package` in Tabby's dependencies. The callback now correctly rejects the Promise when an error occurs, preventing the hard crash and allowing the Tabby CLI to function normally on Wayland.

---

