### PR TITLE
Fix: Restore global "Warn when closing active connection" fallback

### DIFF
--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -198,7 +198,7 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
         if (!this.session?.open) {
             return true
         }
-        if (!this.profile.options.warnOnClose) {
+        if (!(this.profile.options.warnOnClose ?? this.config.store.ssh.warnOnClose)) {
             return true
         }
         return (await this.platform.showMessageBox(


### PR DESCRIPTION
## Summary

* Restores the fallback check to the global `config.store.ssh.warnOnClose` configuration when determining if a warning dialog should be shown upon closing an active SSH connection tab.

## Problem

Active SSH connections close immediately without a warning dialog even if the global setting **"Warn when closing active connections"** is checked. This happens because:

1. `SSHTabComponent.canClose` only checks the profile-specific `this.profile.options.warnOnClose` property.
2. Since `warnOnClose` defaults to `null` for SSH profiles and is not exposed in the individual profile settings UI, the check `!this.profile.options.warnOnClose` always evaluates to `true`.
3. This immediately allows the tab to close, completely ignoring the global configuration check.

## Fix

Updates `canClose` in `sshTab.component.ts` to check `this.profile.options.warnOnClose ?? this.config.store.ssh.warnOnClose`. This allows the global warning preference to be respected when a profile-specific option is not set.

## Fixes

* **"Warn when closing active connection" in ssh configuration no longer work** #11280

## Test plan

- [x] TypeScript compiles with zero errors (`yarn run build`)
- [x] Verified active SSH connection tabs correctly show the disconnect warning dialog when the global setting is enabled
