### PR TITLE
Add sidebar width setting for vertical tabs

### DIFF
--- a/tabby-core/src/components/appRoot.component.scss
+++ b/tabby-core/src/components/appRoot.component.scss
@@ -12,7 +12,8 @@
     transition: 0.25s background;
 
     --tabs-height: calc(38px * var(--spaciness));
-    --side-tab-width: calc(200px * var(--spaciness));
+    --tabs-sidebar-width-factor: 1;
+    --side-tab-width: calc(200px * var(--spaciness) * var(--tabs-sidebar-width-factor));
 }
 
 $tab-border-radius: 4px;

--- a/tabby-core/src/components/appRoot.component.ts
+++ b/tabby-core/src/components/appRoot.component.ts
@@ -207,6 +207,13 @@ export class AppRootComponent {
         return this.config.store.appearance.tabsLocation === 'left' || this.config.store.appearance.tabsLocation === 'right'
     }
 
+    @HostBinding('style.--tabs-sidebar-width-factor') get tabsSidebarWidthFactor (): number {
+        if (!this.hasVerticalTabs() || this.config.store.appearance.flexTabs) {
+            return 1
+        }
+        return Math.min(Math.max(this.config.store.appearance.tabsSidebarWidth ?? 1, 0.5), 3)
+    }
+
     get targetTabSize (): any {
         if (this.hasVerticalTabs()) {
             return '*'

--- a/tabby-core/src/configDefaults.yaml
+++ b/tabby-core/src/configDefaults.yaml
@@ -8,6 +8,7 @@ appearance:
   dockHideOnBlur: false
   dockAlwaysOnTop: true
   flexTabs: false
+  tabsSidebarWidth: 1
   tabsLocation: top
   tabsInFullscreen: false
   cycleTabs: true

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -335,6 +335,20 @@ h3.mt-4(translate) Tabs
 
 .form-line
     .header
+        .title(translate) Sidebar width
+        .description(translate) Adjusts fixed left and right tab sidebar width
+    input(
+        type='range',
+        [(ngModel)]='config.store.appearance.tabsSidebarWidth',
+        (ngModelChange)='saveConfiguration()',
+        min='0.5',
+        max='3',
+        step='0.05',
+        [disabled]='!isTabsSidebarWidthEnabled()'
+    )
+
+.form-line
+    .header
         .title(translate) Show tabs in fullscreen mode
 
     toggle(

--- a/tabby-settings/src/components/windowSettingsTab.component.ts
+++ b/tabby-settings/src/components/windowSettingsTab.component.ts
@@ -57,4 +57,11 @@ export class WindowSettingsTabComponent extends BaseComponent {
             this.config.requestRestart()
         }
     }
+
+    isTabsSidebarWidthEnabled (): boolean {
+        return (
+            (this.config.store.appearance.tabsLocation === 'left' || this.config.store.appearance.tabsLocation === 'right')
+            && !this.config.store.appearance.flexTabs
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add a Window > Tabs "Sidebar width" range setting for left/right tab layouts
- enable the setting only when tabs are placed Left or Right and Tabs width is Fixed
- apply a clamped 50%–300% width factor to the vertical tab sidebar, preserving the existing default width

## Related issues
- Refs #7760 for vertical tabs customization
- Refs #11185 because it requests a configurable sidebar width; this PR scopes the setting to the tab sidebar rather than the profiles/connections sidebar

## Verification
- `yarn install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/eslint tabby-core/src/components/appRoot.component.ts tabby-settings/src/components/windowSettingsTab.component.ts`
- `./node_modules/.bin/pug-lint --config <empty config> tabby-settings/src/components/windowSettingsTab.component.pug`

## Notes
- Full `yarn run lint` was attempted after the ignore-scripts install, but that local setup does not install per-package dependencies and reports unresolved imports outside this change.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 188,147 tokens on this with the user in an interactive session.
