### PR TITLE
Add collapsible vertical tabs

### DIFF
--- a/tabby-core/src/components/appRoot.component.pug
+++ b/tabby-core/src/components/appRoot.component.pug
@@ -11,6 +11,7 @@ title-bar(
     [class.tabs-on-left]='hasVerticalTabs() && config.store.appearance.tabsLocation == "left"',
     [class.tabs-titlebar-enabled]='isTitleBarNeeded()',
     [class.tabs-on-right]='hasVerticalTabs() && config.store.appearance.tabsLocation == "right"',
+    [class.tabs-collapsed]='isVerticalTabsCollapseEnabled()',
 )
     .tab-bar(
         *ngIf='!hostWindow.isFullscreen || config.store.appearance.tabsInFullscreen',

--- a/tabby-core/src/components/appRoot.component.scss
+++ b/tabby-core/src/components/appRoot.component.scss
@@ -92,7 +92,9 @@ $tab-border-radius: 4px;
 
 .content.tabs-collapsed.tabs-on-left > .tab-bar, .content.tabs-collapsed.tabs-on-right > .tab-bar {
     width: var(--collapsed-side-tab-width);
-    transition: width 0.125s ease-out;
+    position: relative;
+    z-index: 2;
+    transition: width 0.125s ease-out, margin 0.125s ease-out;
 
     .tabs {
         width: var(--collapsed-side-tab-width);
@@ -142,6 +144,16 @@ $tab-border-radius: 4px;
             }
         }
     }
+}
+
+.content.tabs-collapsed.tabs-on-left > .tab-bar:hover,
+.content.tabs-collapsed.tabs-on-left > .tab-bar:focus-within {
+    margin-right: calc(var(--collapsed-side-tab-width) - var(--side-tab-width));
+}
+
+.content.tabs-collapsed.tabs-on-right > .tab-bar:hover,
+.content.tabs-collapsed.tabs-on-right > .tab-bar:focus-within {
+    margin-left: calc(var(--collapsed-side-tab-width) - var(--side-tab-width));
 }
 
 .tab-bar {

--- a/tabby-core/src/components/appRoot.component.scss
+++ b/tabby-core/src/components/appRoot.component.scss
@@ -107,6 +107,17 @@ $tab-border-radius: 4px;
         padding: 0;
     }
 
+    .btn-group {
+        width: var(--collapsed-side-tab-width);
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .btn-group > .d-flex {
+        width: 100%;
+        justify-content: center;
+    }
+
     &:hover,
     &:focus-within {
         width: var(--side-tab-width);
@@ -118,6 +129,16 @@ $tab-border-radius: 4px;
         .btn-tab-bar {
             width: auto;
             padding: 0 12px;
+        }
+
+        .btn-group {
+            width: auto;
+            flex-direction: row;
+            align-items: stretch;
+        }
+
+        .btn-group > .d-flex {
+            width: auto;
         }
     }
 

--- a/tabby-core/src/components/appRoot.component.scss
+++ b/tabby-core/src/components/appRoot.component.scss
@@ -13,6 +13,7 @@
 
     --tabs-height: calc(38px * var(--spaciness));
     --side-tab-width: calc(200px * var(--spaciness));
+    --collapsed-side-tab-width: calc(48px * var(--spaciness));
 }
 
 $tab-border-radius: 4px;
@@ -86,6 +87,60 @@ $tab-border-radius: 4px;
     .tabs {
         // Account for WCO on Windows.
         padding-top: 36px;
+    }
+}
+
+.content.tabs-collapsed.tabs-on-left > .tab-bar, .content.tabs-collapsed.tabs-on-right > .tab-bar {
+    width: var(--collapsed-side-tab-width);
+    transition: width 0.125s ease-out;
+
+    .tabs {
+        width: var(--collapsed-side-tab-width);
+        transition: width 0.125s ease-out;
+    }
+
+    .btn-tab-bar {
+        width: var(--collapsed-side-tab-width);
+        justify-content: center;
+        padding: 0;
+    }
+
+    &:hover,
+    &:focus-within {
+        width: var(--side-tab-width);
+
+        .tabs {
+            width: var(--side-tab-width);
+        }
+
+        .btn-tab-bar {
+            width: auto;
+            padding: 0 12px;
+        }
+    }
+
+    &:not(:hover):not(:focus-within) {
+        ::ng-deep tab-header {
+            justify-content: center;
+            padding-left: 0;
+            padding-right: 0;
+
+            .name,
+            .buttons {
+                width: 0;
+                flex: 0 0 0;
+                opacity: 0;
+                pointer-events: none;
+            }
+
+            profile-icon {
+                margin-right: 0;
+            }
+
+            .index {
+                margin-left: 0;
+            }
+        }
     }
 }
 

--- a/tabby-core/src/components/appRoot.component.ts
+++ b/tabby-core/src/components/appRoot.component.ts
@@ -207,6 +207,10 @@ export class AppRootComponent {
         return this.config.store.appearance.tabsLocation === 'left' || this.config.store.appearance.tabsLocation === 'right'
     }
 
+    isVerticalTabsCollapseEnabled () {
+        return this.hasVerticalTabs() && this.config.store.appearance.collapseVerticalTabs
+    }
+
     get targetTabSize (): any {
         if (this.hasVerticalTabs()) {
             return '*'

--- a/tabby-core/src/components/tabHeader.component.pug
+++ b/tabby-core/src/components/tabHeader.component.pug
@@ -7,7 +7,7 @@
 .index(*ngIf='!config.store.terminal.hideTabIndex && hostApp.platform !== Platform.macOS') {{index + 1}}
 
 profile-icon(
-    *ngIf='config.store.terminal.showTabProfileIcon && tab.icon',
+    *ngIf='shouldShowProfileIcon() && tab.icon',
     [icon]='tab.icon',
     [color]='tab.color ?? undefined'
 )

--- a/tabby-core/src/components/tabHeader.component.ts
+++ b/tabby-core/src/components/tabHeader.component.ts
@@ -93,6 +93,17 @@ export class TabHeaderComponent extends BaseComponent {
         return this.config.store.appearance.flexTabs
     }
 
+    shouldShowProfileIcon (): boolean {
+        return this.config.store.terminal.showTabProfileIcon || this.isVerticalTabsCollapseEnabled()
+    }
+
+    private isVerticalTabsCollapseEnabled (): boolean {
+        return (
+            (this.config.store.appearance.tabsLocation === 'left' || this.config.store.appearance.tabsLocation === 'right')
+            && this.config.store.appearance.collapseVerticalTabs
+        )
+    }
+
     @HostListener('dblclick', ['$event']) onDoubleClick ($event: MouseEvent): void {
         this.app.renameTab(this.tab)
         $event.stopPropagation()

--- a/tabby-core/src/configDefaults.yaml
+++ b/tabby-core/src/configDefaults.yaml
@@ -8,6 +8,7 @@ appearance:
   dockHideOnBlur: false
   dockAlwaysOnTop: true
   flexTabs: false
+  collapseVerticalTabs: false
   tabsLocation: top
   tabsInFullscreen: false
   cycleTabs: true

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -335,6 +335,17 @@ h3.mt-4(translate) Tabs
 
 .form-line
     .header
+        .title(translate) Collapse vertical tabs
+        .description(translate) Shows icons only until the tab sidebar is hovered
+
+    toggle(
+        [(ngModel)]='config.store.appearance.collapseVerticalTabs',
+        [disabled]='!hasVerticalTabs()',
+        (ngModelChange)='saveConfiguration();',
+    )
+
+.form-line
+    .header
         .title(translate) Show tabs in fullscreen mode
 
     toggle(

--- a/tabby-settings/src/components/windowSettingsTab.component.ts
+++ b/tabby-settings/src/components/windowSettingsTab.component.ts
@@ -57,4 +57,8 @@ export class WindowSettingsTabComponent extends BaseComponent {
             this.config.requestRestart()
         }
     }
+
+    hasVerticalTabs (): boolean {
+        return this.config.store.appearance.tabsLocation === 'left' || this.config.store.appearance.tabsLocation === 'right'
+    }
 }


### PR DESCRIPTION
## Summary
- add a Window > Tabs "Collapse vertical tabs" setting for left/right tab layouts
- collapse the vertical tab sidebar to icon/index width when enabled
- expand the sidebar on hover or keyboard focus so tab titles and buttons remain accessible

Resolves #7760

## Verification
- `yarn install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/eslint tabby-core/src/components/appRoot.component.ts tabby-settings/src/components/windowSettingsTab.component.ts`
- `./node_modules/.bin/pug-lint --config <empty config> tabby-core/src/components/appRoot.component.pug tabby-settings/src/components/windowSettingsTab.component.pug`

## Notes
- Full `yarn run lint` was attempted after the ignore-scripts install, but this local setup does not install per-package dependencies and reports unresolved imports outside this change.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 20m and 313,334 tokens on this with the user in an interactive session.
