### PR TITLE
fix: recover from bundled plugin load failures

### DIFF
--- a/app/src/entry.ts
+++ b/app/src/entry.ts
@@ -16,6 +16,8 @@ import { ipcRenderer } from 'electron'
 import { getRootModule } from './app.module'
 import { BootstrapData, BOOTSTRAP_DATA, PluginInfo } from '../../tabby-core/src/api/mainProcess'
 
+const SAFE_MODE_BUILTIN_PLUGINS = ['core', 'settings', 'terminal', 'local', 'electron']
+
 // Always land on the start view
 location.hash = ''
 
@@ -33,7 +35,7 @@ if (process.env.TABBY_DEV && !process.env.TABBY_FORCE_ANGULAR_PROD) {
 
 async function bootstrap (bootstrapData: BootstrapData, plugins: PluginInfo[], safeMode = false): Promise<NgModuleRef<any>> {
     if (safeMode) {
-        plugins = plugins.filter(x => x.isBuiltin)
+        plugins = plugins.filter(x => x.isBuiltin && SAFE_MODE_BUILTIN_PLUGINS.includes(x.name))
     }
 
     const pluginModules = await loadPlugins(plugins, (current, total) => {
@@ -52,6 +54,38 @@ async function bootstrap (bootstrapData: BootstrapData, plugins: PluginInfo[], s
         enableDebugTools(componentRef)
     }
     return moduleRef
+}
+
+function showErrorPage (error: any): void {
+    const el = document.querySelector('.preload-logo div')
+    if (!el) {
+        return
+    }
+
+    const errorMessage = String(error?.message || error?.stack || error || 'Unknown error')
+    el.textContent = ''
+
+    const container = document.createElement('div')
+    container.style.cssText = 'text-align: center; padding: 40px 20px; max-width: 560px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;'
+
+    const title = document.createElement('h1')
+    title.textContent = 'Startup Failed'
+    title.style.cssText = 'color: #e06c75; font-size: 22px; font-weight: 600; margin-bottom: 16px;'
+
+    const description = document.createElement('p')
+    description.textContent = 'Tabby could not load one of its bundled plugins. This usually means the installation or portable package is incomplete, stale, or missing a native dependency.'
+    description.style.cssText = 'color: #abb2bf; font-size: 14px; margin-bottom: 12px; line-height: 1.7;'
+
+    const details = document.createElement('pre')
+    details.textContent = errorMessage
+    details.style.cssText = 'background: #1e222a; color: #e06c75; padding: 12px; border-radius: 6px; font-size: 12px; text-align: left; overflow-x: auto; margin: 16px 0; white-space: pre-wrap; word-break: break-all; max-height: 180px; font-family: "SF Mono", "Cascadia Code", monospace; border: 1px solid #3e4451;'
+
+    const action = document.createElement('p')
+    action.style.cssText = 'color: #abb2bf; font-size: 13px; line-height: 1.8;'
+    action.innerHTML = '<strong style="color: #e5c07b;">To fix this:</strong><br>Reinstall Tabby from the latest release, or fully extract the portable package into an empty directory. Your settings will be preserved.<br><br>Press <kbd style="background: #3e4451; padding: 2px 7px; border-radius: 3px; border: 1px solid #5c6370; font-family: monospace;">Ctrl+Shift+I</kbd> to open DevTools for detailed logs.'
+
+    container.append(title, description, details, action)
+    el.append(container)
 }
 
 ipcRenderer.once('start', async (_$event, bootstrapData: BootstrapData) => {
@@ -77,6 +111,7 @@ ipcRenderer.once('start', async (_$event, bootstrapData: BootstrapData) => {
             await bootstrap(bootstrapData, plugins, true)
         } catch (error2) {
             console.error('Bootstrap failed:', error2)
+            showErrorPage(error2)
         }
     }
 })

--- a/app/src/plugins.ts
+++ b/app/src/plugins.ts
@@ -238,7 +238,7 @@ export async function loadPlugins (foundPlugins: PluginInfo[], progress: Progres
 
     progress(0, 1)
     for (const foundPlugin of foundPlugins) {
-        pluginsPromises.push(new Promise(x => {
+        pluginsPromises.push(new Promise((resolve, reject) => {
             console.info(`Loading ${foundPlugin.name}: ${nodeRequire.resolve(foundPlugin.path)}`)
             try {
                 const packageModule = nodeRequire(foundPlugin.path)
@@ -251,9 +251,16 @@ export async function loadPlugins (foundPlugins: PluginInfo[], progress: Progres
                 plugins.push(pluginModule)
             } catch (error) {
                 console.error(`Could not load ${foundPlugin.name}:`, error)
+                if (foundPlugin.isBuiltin) {
+                    const pluginError = new Error(`Could not load bundled plugin ${foundPlugin.packageName} from ${foundPlugin.path}: ${(error as any)?.message ?? error}`)
+                    pluginError.stack = (error as any)?.stack ?? pluginError.stack
+                    setProgress()
+                    reject(pluginError)
+                    return
+                }
             }
             setProgress()
-            setTimeout(x, 50)
+            setTimeout(resolve, 50)
         }))
     }
     await Promise.all(pluginsPromises)

--- a/app/src/plugins.ts
+++ b/app/src/plugins.ts
@@ -252,8 +252,8 @@ export async function loadPlugins (foundPlugins: PluginInfo[], progress: Progres
             } catch (error) {
                 console.error(`Could not load ${foundPlugin.name}:`, error)
                 if (foundPlugin.isBuiltin) {
-                    const pluginError = new Error(`Could not load bundled plugin ${foundPlugin.packageName} from ${foundPlugin.path}: ${(error as any)?.message ?? error}`)
-                    pluginError.stack = (error as any)?.stack ?? pluginError.stack
+                    const pluginError = new Error(`Could not load bundled plugin ${foundPlugin.packageName} from ${foundPlugin.path}: ${error?.message ?? error}`)
+                    pluginError.stack = error?.stack ?? pluginError.stack
                     setProgress()
                     reject(pluginError)
                     return

--- a/tabby-core/src/components/safeModeModal.component.pug
+++ b/tabby-core/src/components/safeModeModal.component.pug
@@ -1,5 +1,5 @@
 .modal-body
-    .alert.alert-danger(translate) Tabby could not start with your plugins, so all third party plugins have been disabled in this session. The error was:
+    .alert.alert-danger(translate) Tabby could not start with all plugins enabled, so optional and third-party plugins have been disabled in this session. The error was:
 
     pre {{error}}
 


### PR DESCRIPTION
## Summary

Fix bundled plugin load failures so Tabby does not get stuck at the splash screen when a built-in plugin fails to load a native dependency.

This supersedes the earlier app.asar fallback idea: bundled plugins are loaded from `resources/builtin-plugins`, not from `app.asar`. The real failure mode in #10409 is that a bundled plugin (`tabby-ssh`) can throw while loading `russh`, and the current loader only logs the error. Tabby then continues with an incomplete built-in plugin set, which can leave the renderer stuck or half-started.

## Changes

- Treat bundled plugin load failures as startup failures instead of silently skipping them.
- Retry startup in a minimal safe mode that only loads core built-ins: `core`, `settings`, `terminal`, `local`, and `electron`.
- Keep third-party plugin load failures non-fatal.
- Show a clear startup error page if even minimal safe mode cannot boot.
- Update the safe mode modal text because safe mode can now disable optional bundled plugins as well as third-party plugins.

## Why this fixes the Windows failure mode

In #10409, `tabby-ssh` fails while loading `russh.win32-x64-msvc.node`. That native module error should not leave the whole app frozen. With this change, the first bootstrap attempt fails fast, then safe mode excludes optional native-plugin surfaces like SSH/Serial/Telnet and allows the rest of the app to start.

Fixes #10409.

## Testing

- `git diff --check`
- Tried `yarn lint`, but this local checkout does not have dependencies installed (`eslint` is missing). GitHub Actions should run the full lint/build matrix.