### PR TITLE
feat: Add mouse wheel support for hotkeys

### DIFF
--- a/tabby-core/src/services/hotkeys.service.ts
+++ b/tabby-core/src/services/hotkeys.service.ts
@@ -20,7 +20,7 @@ interface PastKeystroke {
 @Injectable({ providedIn: 'root' })
 export class HotkeysService {
     /** @hidden @deprecated */
-    key = new EventEmitter<KeyboardEvent>()
+    key = new EventEmitter<KeyboardEvent|WheelEvent|MouseEvent>()
 
     /** @hidden @deprecated */
     matchedHotkey = new EventEmitter<string>()
@@ -52,7 +52,7 @@ export class HotkeysService {
     /**
      * Fired for each key event
      */
-    get keyEvent$ (): Observable<KeyboardEvent> { return this._keyEvent }
+    get keyEvent$ (): Observable<KeyboardEvent|WheelEvent|MouseEvent> { return this._keyEvent }
 
     /**
      * Fired for each singular key combination
@@ -61,7 +61,7 @@ export class HotkeysService {
 
     private _hotkey = new Subject<string>()
     private _hotkeyOff = new Subject<string>()
-    private _keyEvent = new Subject<KeyboardEvent>()
+    private _keyEvent = new Subject<KeyboardEvent|WheelEvent|MouseEvent>()
     private _key = new Subject<KeyName>()
     private _keystroke = new Subject<Keystroke>()
     private disabledLevel = 0
@@ -74,6 +74,7 @@ export class HotkeysService {
     private lastKeystrokes: PastKeystroke[] = []
     private recognitionPhase = true
     private lastEventTimestamp = 0
+    private lastMiddleClickTimestamp: number|null = null
 
     private constructor (
         private zone: NgZone,
@@ -84,18 +85,29 @@ export class HotkeysService {
         this.config.ready$.toPromise().then(async () => {
             const hotkeys = await this.getHotkeyDescriptions()
             this.hotkeyDescriptions = hotkeys
-            const events = ['keydown', 'keyup']
 
-            events.forEach(eventType => {
-                document.addEventListener(eventType, (nativeEvent: KeyboardEvent) => {
-                    this._keyEvent.next(nativeEvent)
-                    this.pushKeyEvent(eventType, nativeEvent)
+            const registerEvent = (
+                eventType: 'keydown'|'keyup'|'wheel'|'mouseup'|'auxclick',
+                filterEvent?: (event: KeyboardEvent|WheelEvent|MouseEvent) => boolean,
+            ) => {
+                document.addEventListener(eventType, event => {
+                    if (filterEvent && !filterEvent(event)) {
+                        return
+                    }
+                    this._keyEvent.next(event)
+                    this.pushKeyEvent(eventType, event)
                     if (hostApp.platform === Platform.Web && this.matchActiveHotkey(true) !== null) {
-                        nativeEvent.preventDefault()
-                        nativeEvent.stopPropagation()
+                        event.preventDefault()
+                        event.stopPropagation()
                     }
                 })
-            })
+            }
+
+            registerEvent('keydown')
+            registerEvent('keyup')
+            registerEvent('wheel')
+            registerEvent('mouseup', event => 'button' in event && event.button === 1)
+            registerEvent('auxclick', event => 'button' in event && event.button === 1)
         })
 
         // deprecated
@@ -111,7 +123,7 @@ export class HotkeysService {
      * @param eventName DOM event name
      * @param nativeEvent event object
      */
-    pushKeyEvent (eventName: string, nativeEvent: KeyboardEvent): void {
+    pushKeyEvent (eventName: string, nativeEvent: KeyboardEvent|WheelEvent|MouseEvent): void {
         if (nativeEvent.timeStamp === this.lastEventTimestamp) {
             return
         }
@@ -123,8 +135,11 @@ export class HotkeysService {
             metaKey: nativeEvent.metaKey,
             altKey: nativeEvent.altKey,
             shiftKey: nativeEvent.shiftKey,
-            code: nativeEvent.code,
-            key: nativeEvent.key,
+            code: 'code' in nativeEvent ? nativeEvent.code : '',
+            key: 'key' in nativeEvent ? nativeEvent.key : '',
+            deltaX: 'deltaX' in nativeEvent ? nativeEvent.deltaX : undefined,
+            deltaY: 'deltaY' in nativeEvent ? nativeEvent.deltaY : undefined,
+            button: 'button' in nativeEvent ? nativeEvent.button : undefined,
             eventName,
             time: nativeEvent.timeStamp,
             registrationTime: performance.now(),
@@ -137,6 +152,15 @@ export class HotkeysService {
         }
 
         const keyName = getKeyName(eventData)
+        if (keyName === 'MiddleClick') {
+            if (eventName === 'auxclick' && this.lastMiddleClickTimestamp !== null && nativeEvent.timeStamp - this.lastMiddleClickTimestamp < 300) {
+                return
+            }
+            if (eventName === 'mouseup') {
+                this.lastMiddleClickTimestamp = nativeEvent.timeStamp
+            }
+        }
+
         if (eventName === 'keydown') {
             this.addPressedKey(keyName, eventData)
             this.recognitionPhase = true
@@ -144,7 +168,7 @@ export class HotkeysService {
         }
         if (eventName === 'keyup') {
             const keystroke = getKeystrokeName([...this.pressedKeys])
-            if (this.recognitionPhase) {
+            if (keystroke && this.recognitionPhase) {
                 this._keystroke.next(keystroke)
                 this.lastKeystrokes.push({
                     keystroke,
@@ -155,6 +179,18 @@ export class HotkeysService {
             this.pressedKeys.clear()
             this.pressedKeyTimestamps.clear()
             this.removePressedKey(keyName)
+        }
+        if (eventName === 'wheel' || eventName === 'mouseup' || eventName === 'auxclick') {
+            this.updateModifiers(eventData)
+            this.addPressedKey(keyName, eventData)
+            const keystroke = getKeystrokeName([...this.pressedKeys])
+            this._keystroke.next(keystroke)
+            this.lastKeystrokes.push({
+                keystroke,
+                time: performance.now(),
+            })
+            this.pressedKeystroke = keystroke
+            this.recognitionPhase = true
         }
 
         if (this.pressedKeys.size) {
@@ -168,6 +204,9 @@ export class HotkeysService {
             if (matched) {
                 if (this.recognitionPhase) {
                     this.emitHotkeyOn(matched)
+                    if (eventName === 'wheel' || eventName === 'mouseup' || eventName === 'auxclick') {
+                        this.emitHotkeyOff(matched)
+                    }
                 }
             } else if (this.pressedHotkey) {
                 this.emitHotkeyOff(this.pressedHotkey)
@@ -181,6 +220,12 @@ export class HotkeysService {
         if (process.platform === 'darwin' && eventData.metaKey && eventName === 'keydown' && !['Ctrl', 'Shift', altKeyName, metaKeyName, 'Enter'].includes(keyName)) {
             // macOS will swallow non-modified keyups if Cmd is held down
             this.pushKeyEvent('keyup', nativeEvent)
+        }
+
+        if (eventName === 'wheel' || eventName === 'mouseup' || eventName === 'auxclick') {
+            this.pressedKeys.clear()
+            this.pressedKeyTimestamps.clear()
+            this.pressedKeystroke = null
         }
 
         this.lastEventTimestamp = nativeEvent.timeStamp

--- a/tabby-core/src/services/hotkeys.service.ts
+++ b/tabby-core/src/services/hotkeys.service.ts
@@ -156,8 +156,8 @@ export class HotkeysService {
 
         const keyName = getKeyName(eventData)
 
-        // After the first wheel event, ignore additional wheel events for a short interval
-        if (eventName === 'wheel') {
+        // During hotkey recording, ignore additional wheel events for a short interval
+        if (eventName === 'wheel' && !this.isEnabled()) {
             if (this.lastWheelTimestamp !== null && nativeEvent.timeStamp - this.lastWheelTimestamp < WHEEL_EVENT_INTERVAL_MS) {
                 return
             }

--- a/tabby-core/src/services/hotkeys.service.ts
+++ b/tabby-core/src/services/hotkeys.service.ts
@@ -17,6 +17,8 @@ interface PastKeystroke {
     time: number
 }
 
+const WHEEL_EVENT_INTERVAL_MS = 250
+
 @Injectable({ providedIn: 'root' })
 export class HotkeysService {
     /** @hidden @deprecated */
@@ -75,7 +77,7 @@ export class HotkeysService {
     private recognitionPhase = true
     private suppressNextKeyupKeystroke = false
     private lastEventTimestamp = 0
-    private lastMiddleClickTimestamp: number|null = null
+    private lastWheelTimestamp: number|null = null
 
     private constructor (
         private zone: NgZone,
@@ -153,13 +155,13 @@ export class HotkeysService {
         }
 
         const keyName = getKeyName(eventData)
-        if (keyName === 'MiddleClick') {
-            if (eventName === 'auxclick' && this.lastMiddleClickTimestamp !== null && nativeEvent.timeStamp - this.lastMiddleClickTimestamp < 300) {
+
+        // After the first wheel event, ignore additional wheel events for a short interval
+        if (eventName === 'wheel') {
+            if (this.lastWheelTimestamp !== null && nativeEvent.timeStamp - this.lastWheelTimestamp < WHEEL_EVENT_INTERVAL_MS) {
                 return
             }
-            if (eventName === 'mouseup') {
-                this.lastMiddleClickTimestamp = nativeEvent.timeStamp
-            }
+            this.lastWheelTimestamp = nativeEvent.timeStamp
         }
 
         if (eventName === 'keydown') {

--- a/tabby-core/src/services/hotkeys.service.ts
+++ b/tabby-core/src/services/hotkeys.service.ts
@@ -73,6 +73,7 @@ export class HotkeysService {
     private pressedKeystroke: Keystroke|null = null
     private lastKeystrokes: PastKeystroke[] = []
     private recognitionPhase = true
+    private suppressNextKeyupKeystroke = false
     private lastEventTimestamp = 0
     private lastMiddleClickTimestamp: number|null = null
 
@@ -164,11 +165,16 @@ export class HotkeysService {
         if (eventName === 'keydown') {
             this.addPressedKey(keyName, eventData)
             this.recognitionPhase = true
+            if (!(nativeEvent as KeyboardEvent).repeat) {
+                this.suppressNextKeyupKeystroke = false
+            }
             this.updateModifiers(eventData)
         }
         if (eventName === 'keyup') {
+            const shouldSuppressKeystroke = this.suppressNextKeyupKeystroke
+            this.suppressNextKeyupKeystroke = false
             const keystroke = getKeystrokeName([...this.pressedKeys])
-            if (keystroke && this.recognitionPhase) {
+            if (!shouldSuppressKeystroke && keystroke && this.recognitionPhase) {
                 this._keystroke.next(keystroke)
                 this.lastKeystrokes.push({
                     keystroke,
@@ -191,6 +197,7 @@ export class HotkeysService {
             })
             this.pressedKeystroke = keystroke
             this.recognitionPhase = true
+            this.suppressNextKeyupKeystroke = true
         }
 
         if (this.pressedKeys.size) {
@@ -223,6 +230,7 @@ export class HotkeysService {
         }
 
         if (eventName === 'wheel' || eventName === 'mouseup' || eventName === 'auxclick') {
+            this.recognitionPhase = false
             this.pressedKeys.clear()
             this.pressedKeyTimestamps.clear()
             this.pressedKeystroke = null

--- a/tabby-core/src/services/hotkeys.util.ts
+++ b/tabby-core/src/services/hotkeys.util.ts
@@ -16,8 +16,11 @@ export interface KeyEventData {
     metaKey?: boolean
     altKey?: boolean
     shiftKey?: boolean
-    key: string
-    code: string
+    key?: string
+    code?: string
+    deltaX?: number
+    deltaY?: number
+    button?: number
     eventName: string
     time: number
     registrationTime: number
@@ -29,6 +32,25 @@ export type KeyName = string
 export type Keystroke = string
 
 export function getKeyName (event: KeyEventData): KeyName {
+    if (event.eventName === 'mouseup' || event.eventName === 'auxclick') {
+        if (event.button === 1) {
+            return 'MiddleClick'
+        }
+        return 'Mouse'
+    }
+
+    if (event.eventName === 'wheel') {
+        const deltaX = event.deltaX ?? 0
+        const deltaY = event.deltaY ?? 0
+        if (Math.abs(deltaY) >= Math.abs(deltaX) && deltaY !== 0) {
+            return deltaY < 0 ? 'WheelUp' : 'WheelDown'
+        }
+        if (deltaX !== 0) {
+            return deltaX < 0 ? 'WheelLeft' : 'WheelRight'
+        }
+        return 'Wheel'
+    }
+
     // eslint-disable-next-line @typescript-eslint/init-declarations
     let key: string
     if (event.key === 'Control') {
@@ -44,8 +66,8 @@ export function getKeyName (event: KeyEventData): KeyName {
     } else if (event.key === '~') {
         key = '~'
     } else {
-        key = event.code
-        if (REGEX_LATIN_KEYNAME.test(event.key)) {
+        key = event.code ?? ''
+        if (event.key && REGEX_LATIN_KEYNAME.test(event.key)) {
             // Handle Dvorak etc via the reported "character" instead of the scancode
             key = event.key.toUpperCase()
         } else {

--- a/tabby-settings/src/components/hotkeyInputModal.component.ts
+++ b/tabby-settings/src/components/hotkeyInputModal.component.ts
@@ -55,16 +55,8 @@ export class HotkeyInputModalComponent extends BaseComponent {
         })
         this.subscribeUntilDestroyed(hotkeys.keystroke$, keystroke => {
             this.lastKeyEvent = performance.now()
-            if (this.isWheelKeystroke(keystroke) && this.value.length && this.isWheelKeystroke(this.value[this.value.length - 1])) {
-                this.value[this.value.length - 1] = keystroke
-                return
-            }
             this.value.push(keystroke)
         })
-    }
-
-    private isWheelKeystroke (keystroke: Keystroke): boolean {
-        return /(^|-)Wheel(Up|Down|Left|Right)$/.test(keystroke)
     }
 
     splitKeys (keys: string): string[] {

--- a/tabby-settings/src/components/hotkeyInputModal.component.ts
+++ b/tabby-settings/src/components/hotkeyInputModal.component.ts
@@ -55,8 +55,16 @@ export class HotkeyInputModalComponent extends BaseComponent {
         })
         this.subscribeUntilDestroyed(hotkeys.keystroke$, keystroke => {
             this.lastKeyEvent = performance.now()
+            if (this.isWheelKeystroke(keystroke) && this.value.length && this.isWheelKeystroke(this.value[this.value.length - 1])) {
+                this.value[this.value.length - 1] = keystroke
+                return
+            }
             this.value.push(keystroke)
         })
+    }
+
+    private isWheelKeystroke (keystroke: Keystroke): boolean {
+        return /(^|-)Wheel(Up|Down|Left|Right)$/.test(keystroke)
     }
 
     splitKeys (keys: string): string[] {

--- a/tabby-settings/src/components/hotkeySettingsTab.component.pug
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.pug
@@ -5,12 +5,14 @@ h3.mb-3(translate) Hotkeys
         i.fas.fa-fw.fa-search
     input.form-control(type='search', [placeholder]='"Search hotkeys"|translate', [(ngModel)]='hotkeyFilter')
 
-.mb-3.hotkeys-table
+.mb-3
     ng-container(*ngFor='let hotkey of hotkeyDescriptions')
         .row.align-items-center(*ngIf='!hotkeyFilter || hotkeyFilterFn(hotkey, hotkeyFilter)')
-            .col-8.py-2
-                span {{hotkey.name|translate}}
-                span.ms-2.text-muted ({{hotkey.id}})
+            .col-8.py-2.hotkey-name-cell
+                span(
+                    [ngbTooltip]='hotkey.id',
+                    (click)='copyId(hotkey.id)'
+                ) {{hotkey.name|translate}}
             .col-4.pe-5
                 multi-hotkey-input(
                     [hotkeys]='getHotkeys(hotkey.id) || []',

--- a/tabby-settings/src/components/hotkeySettingsTab.component.scss
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.scss
@@ -1,0 +1,3 @@
+.hotkey-name-cell > div {
+    cursor: pointer;
+}

--- a/tabby-settings/src/components/hotkeySettingsTab.component.ts
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.ts
@@ -7,7 +7,7 @@ import {
     HotkeyDescription,
     HotkeysService,
     HostAppService,
-} from 'tabby-core'
+    PlatformService } from 'tabby-core'
 
 _('Search hotkeys')
 
@@ -15,6 +15,7 @@ _('Search hotkeys')
 @Component({
     selector: 'hotkey-settings-tab',
     templateUrl: './hotkeySettingsTab.component.pug',
+    styleUrls: ['./hotkeySettingsTab.component.scss'],
 })
 export class HotkeySettingsTabComponent {
     hotkeyFilter = ''
@@ -25,6 +26,7 @@ export class HotkeySettingsTabComponent {
         public config: ConfigService,
         public hostApp: HostAppService,
         public zone: NgZone,
+        private platform: PlatformService,
         hotkeys: HotkeysService,
     ) {
         hotkeys.getHotkeyDescriptions().then(descriptions => {
@@ -54,6 +56,12 @@ export class HotkeySettingsTabComponent {
         )
         this.config.save()
         this.allDuplicateHotkeys = this.getAllDuplicateHotkeys()
+    }
+
+    copyId (id: string) {
+        this.platform.setClipboard({
+            text: id,
+        })
     }
 
     hotkeyFilterFn (hotkey: HotkeyDescription, query: string): boolean {

--- a/tabby-settings/src/components/multiHotkeyInput.component.pug
+++ b/tabby-settings/src/components/multiHotkeyInput.component.pug
@@ -1,8 +1,8 @@
-.item(*ngFor='let hotkey of hotkeys')
-    .body((click)='editItem(hotkey)')
+.item(*ngFor='let hotkey of hotkeys; let i = index')
+    .body((mousedown)='openEditorByMouse($event, i)')
         .stroke(*ngFor='let stroke of castAny(hotkey.strokes)')
             span(*ngIf='!hotkey.isDuplicate') {{stroke}}
             span.duplicate(*ngIf='hotkey.isDuplicate') {{stroke}}
-    .remove((click)='removeItem(hotkey)') &times;
+    .remove((mousedown)='removeByMouse($event, i)') &times;
 
 .add((click)='addItem()', translate) Add...

--- a/tabby-settings/src/components/multiHotkeyInput.component.pug
+++ b/tabby-settings/src/components/multiHotkeyInput.component.pug
@@ -1,8 +1,8 @@
 .item(*ngFor='let hotkey of hotkeys; let i = index')
-    .body((mousedown)='openEditorByMouse($event, i)')
+    .body((click)='editItem(i)')
         .stroke(*ngFor='let stroke of castAny(hotkey.strokes)')
             span(*ngIf='!hotkey.isDuplicate') {{stroke}}
             span.duplicate(*ngIf='hotkey.isDuplicate') {{stroke}}
-    .remove((mousedown)='removeByMouse($event, i)') &times;
+    .remove((click)='removeItem(i)') &times;
 
 .add((click)='addItem()', translate) Add...

--- a/tabby-settings/src/components/multiHotkeyInput.component.scss
+++ b/tabby-settings/src/components/multiHotkeyInput.component.scss
@@ -3,7 +3,7 @@
     flex-wrap: nowrap;
 
     &:hover .add {
-      display: initial;
+        opacity: 1;
     }
 }
 
@@ -27,9 +27,9 @@
 
 .add {
     flex: auto;
-    display: none;
+    opacity: 0;
 
     &:first-child {
-        display: block;
+        opacity: 1;
     }
 }

--- a/tabby-settings/src/components/multiHotkeyInput.component.scss
+++ b/tabby-settings/src/components/multiHotkeyInput.component.scss
@@ -1,6 +1,10 @@
 :host {
     display: flex;
     flex-wrap: nowrap;
+
+    &:hover .add {
+      display: initial;
+    }
 }
 
 .item {
@@ -22,7 +26,10 @@
 }
 
 .add {
-    flex: none;
-    display: block;
-    white-space: nowrap;
+    flex: auto;
+    display: none;
+
+    &:first-child {
+        display: block;
+    }
 }

--- a/tabby-settings/src/components/multiHotkeyInput.component.scss
+++ b/tabby-settings/src/components/multiHotkeyInput.component.scss
@@ -1,10 +1,6 @@
 :host {
     display: flex;
     flex-wrap: nowrap;
-
-    &:hover .add {
-      display: initial;
-    }
 }
 
 .item {
@@ -26,10 +22,7 @@
 }
 
 .add {
-    flex: auto;
-    display: none;
-
-    &:first-child {
-        display: block;
-    }
+    flex: none;
+    display: block;
+    white-space: nowrap;
 }

--- a/tabby-settings/src/components/multiHotkeyInput.component.ts
+++ b/tabby-settings/src/components/multiHotkeyInput.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { HotkeyInputModalComponent } from './hotkeyInputModal.component'
 import { Hotkey } from 'tabby-core'
-import deepEqual from 'deep-equal'
 
 /** @hidden */
 @Component({
@@ -23,23 +22,43 @@ export class MultiHotkeyInputComponent {
         this.hotkeys = this.hotkeys.map(hotkey => typeof hotkey.strokes === 'string' ? { ...hotkey, strokes: [hotkey.strokes] } : hotkey)
     }
 
-    editItem (item: Hotkey): void {
+    editItem (index: number): void {
         this.ngbModal.open(HotkeyInputModalComponent).result.then((newStrokes: string[]) => {
-            this.hotkeys.find(hotkey => deepEqual(hotkey.strokes, item.strokes))!.strokes = newStrokes
-            this.storeUpdatedHotkeys()
+            if (this.hotkeys[index]) {
+                this.hotkeys[index].strokes = newStrokes
+                this.storeUpdatedHotkeys()
+            }
         })
+    }
+
+    openEditorByMouse (event: MouseEvent, index: number): void {
+        if (event.button !== 0) {
+            return
+        }
+        event.preventDefault()
+        event.stopPropagation()
+        this.editItem(index)
     }
 
     addItem (): void {
         this.ngbModal.open(HotkeyInputModalComponent).result.then((value: string[]) => {
-            this.hotkeys.push({ strokes: value, isDuplicate: false })
+            this.hotkeys = [...this.hotkeys, { strokes: value, isDuplicate: false }]
             this.storeUpdatedHotkeys()
         })
     }
 
-    removeItem (item: Hotkey): void {
-        this.hotkeys = this.hotkeys.filter(x => x !== item)
+    removeItem (index: number): void {
+        this.hotkeys = this.hotkeys.filter((_, i) => i !== index)
         this.storeUpdatedHotkeys()
+    }
+
+    removeByMouse (event: MouseEvent, index: number): void {
+        if (event.button !== 0) {
+            return
+        }
+        event.preventDefault()
+        event.stopPropagation()
+        this.removeItem(index)
     }
 
     private storeUpdatedHotkeys () {

--- a/tabby-settings/src/components/multiHotkeyInput.component.ts
+++ b/tabby-settings/src/components/multiHotkeyInput.component.ts
@@ -31,15 +31,6 @@ export class MultiHotkeyInputComponent {
         })
     }
 
-    openEditorByMouse (event: MouseEvent, index: number): void {
-        if (event.button !== 0) {
-            return
-        }
-        event.preventDefault()
-        event.stopPropagation()
-        this.editItem(index)
-    }
-
     addItem (): void {
         this.ngbModal.open(HotkeyInputModalComponent).result.then((value: string[]) => {
             this.hotkeys = [...this.hotkeys, { strokes: value, isDuplicate: false }]
@@ -50,15 +41,6 @@ export class MultiHotkeyInputComponent {
     removeItem (index: number): void {
         this.hotkeys = this.hotkeys.filter((_, i) => i !== index)
         this.storeUpdatedHotkeys()
-    }
-
-    removeByMouse (event: MouseEvent, index: number): void {
-        if (event.button !== 0) {
-            return
-        }
-        event.preventDefault()
-        event.stopPropagation()
-        this.removeItem(index)
     }
 
     private storeUpdatedHotkeys () {


### PR DESCRIPTION
## Summary
Support wheel and middle-click hotkeys: WheelUp / WheelDown / WheelLeft / WheelRight / MiddleClick
This also enables zooming in and out of the device using the mouse wheel's hotkeys.

<img width="800" height="293" alt="2026-06-03 101456" src="https://github.com/user-attachments/assets/fef028d1-95a5-4fc6-bb64-204e4d6c4420" />

## Related issues
https://github.com/Eugeny/tabby/issues/9677
https://github.com/Eugeny/tabby/issues/10427
